### PR TITLE
Fix convertion to primitive when big integer is negative. 

### DIFF
--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/integer/BigInteger.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/integer/BigInteger.kt
@@ -705,28 +705,28 @@ class BigInteger internal constructor(wordArray: WordArray, val sign: Sign) : Bi
         if (exactRequired && this > Int.MAX_VALUE.toUInt()) {
             throw ArithmeticException("Cannot convert to int and provide exact value")
         }
-        return magnitude[0].toInt()
+        return magnitude[0].toInt() * signum()
     }
 
     override fun longValue(exactRequired: Boolean): Long {
         if (exactRequired && (this > Long.MAX_VALUE.toUInt())) {
             throw ArithmeticException("Cannot convert to long and provide exact value")
         }
-        return magnitude[0].toLong()
+        return magnitude[0].toLong() * signum()
     }
 
     override fun byteValue(exactRequired: Boolean): Byte {
         if (exactRequired && this > Byte.MAX_VALUE.toUInt()) {
             throw ArithmeticException("Cannot convert to byte and provide exact value")
         }
-        return magnitude[0].toByte()
+        return (magnitude[0].toByte() * signum()).toByte()
     }
 
     override fun shortValue(exactRequired: Boolean): Short {
         if (exactRequired && this > Short.MAX_VALUE.toUInt()) {
             throw ArithmeticException("Cannot convert to short and provide exact value")
         }
-        return magnitude[0].toShort()
+        return (magnitude[0].toShort() * signum()).toShort()
     }
 
     override fun uintValue(exactRequired: Boolean): UInt {

--- a/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/integer/ConversionTest.kt
+++ b/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/integer/ConversionTest.kt
@@ -18,6 +18,7 @@
 package com.ionspin.kotlin.bignum.integer.arithmetic
 
 import com.ionspin.kotlin.bignum.integer.BigInteger
+import com.ionspin.kotlin.bignum.integer.toBigInteger
 import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
@@ -161,6 +162,35 @@ class ConversionTest {
         assertTrue {
             val bigInt = BigInteger.tryFromDouble(Double.MIN_VALUE)
             bigInt.doubleValue() == 0.0
+        }
+    }
+
+    @Test
+    fun testPrimitiveConversionSignValues() {
+        assertTrue {
+            -1.toBigInteger().longValue() == -1L
+        }
+        assertTrue {
+            -1.toBigInteger().intValue() == -1
+        }
+        assertTrue {
+            -1.toBigInteger().shortValue() == -1
+        }
+        assertTrue {
+            -1.toBigInteger().byteValue() == -1
+        }
+
+        assertTrue {
+            1.toBigInteger().longValue() == 1L
+        }
+        assertTrue {
+            1.toBigInteger().intValue() == 1
+        }
+        assertTrue {
+            1.toBigInteger().shortValue() == 1.toShort()
+        }
+        assertTrue {
+            1.toBigInteger().byteValue() == 1.toByte()
         }
     }
 }


### PR DESCRIPTION
The conversion was disregarding the sign of the big integer.
The issue was reported by Omar Alejandro Mainegra Sarduy on Gitter