### PR TITLE
BigInteger wrong negative comparison

### DIFF
--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/integer/BigInteger.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/integer/BigInteger.kt
@@ -422,7 +422,12 @@ class BigInteger internal constructor(wordArray: WordArray, val sign: Sign) : Bi
         if (this.isZero() && other.sign == Sign.POSITIVE) return -1
         if (this.isZero() && other.sign == Sign.NEGATIVE) return 1
         if (sign != other.sign) return if (sign == Sign.POSITIVE) 1 else -1
-        return arithmetic.compare(this.magnitude, other.magnitude)
+        val result = arithmetic.compare(this.magnitude, other.magnitude)
+        return if (this.sign == Sign.NEGATIVE && other.sign == Sign.NEGATIVE) {
+            result * -1
+        } else {
+            result
+        }
     }
 
     override fun isZero(): Boolean {

--- a/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/integer/BigIntegerTest.kt
+++ b/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/integer/BigIntegerTest.kt
@@ -397,4 +397,25 @@ BigIntegerTest {
             b.compareTo(a) == 0
         }
     }
+
+    @Test
+    fun testComparisonsWithSigns() {
+        assertTrue {
+            val smaller = (-10).toBigInteger()
+            val bigger = (-5).toBigInteger()
+            smaller < bigger
+        }
+
+        assertTrue {
+            val smaller = (-10).toBigInteger()
+            val bigger = (5).toBigInteger()
+            smaller < bigger
+        }
+
+        assertTrue {
+            val smaller = (5).toBigInteger()
+            val bigger = (10).toBigInteger()
+            smaller < bigger
+        }
+    }
 }


### PR DESCRIPTION
would return wrong value when comparing two negative values, as the arithmetic comparison function doesn't take sign into account, and it wasn't handled in BigInteger arithmetic wrapper, fixes #114