### PR TITLE
116 support win/mac jvm development

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text eol=lf
+* text=auto eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-* text=auto eol=lf
+* text=auto 

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ matrix:
       before_install:
         - curl "${GRAVIS}.install-jdk-travis.sh" --output ~/.install-jdk-travis.sh
         - source ~/.install-jdk-travis.sh
+        - git config --global core.autocrlf false
       script:
         - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then ./gradlew build; fi'
         - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then ./gradlew build publishMingwx64PublicationToSnapshotRepository; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ matrix:
       before_install:
         - curl "${GRAVIS}.install-jdk-travis.sh" --output ~/.install-jdk-travis.sh
         - source ~/.install-jdk-travis.sh
-        - git config --global core.autocrlf false
       script:
         - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then ./gradlew build; fi'
         - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then ./gradlew build publishMingwx64PublicationToSnapshotRepository; fi'

--- a/README.md
+++ b/README.md
@@ -533,7 +533,7 @@ If you want to try building BigNum library yourself, those are the sources I wou
 ### Development environment
 If you are planning on contributing to the development of the library, you can set a local gradle variable
 in `gradle.properties` in your gradle home directory (i.e. on Linux ~/.gradle/gradle.properties) called
-`bignumDevelopmentEnvironmentOs` to `linux`, `windows` or `mac` so that the gradle builds JVM and JS targets on your 
+`bignumPrimaryDevelopmentOs` to `linux`, `windows` or `mac` so that the gradle builds JVM and JS targets on your 
 platform. The reason for this switch is that most of the test are run on JVM by comparing results to Java BigInteger/Decimal
 so they should be run on your main development OS to verify proper results, and can be skipped on other operating systems
 where you are developing that platform specific features.

--- a/README.md
+++ b/README.md
@@ -529,3 +529,13 @@ Yiping Cheng, Ze Liu
 And many other blogs and posts scattered over the internet.
 
 If you want to try building BigNum library yourself, those are the sources I would recommend to start with.
+
+### Development environment
+If you are planning on contributing to the development of the library, you can set a local gradle variable
+in `gradle.properties` in your gradle home directory (i.e. on Linux ~/.gradle/gradle.properties) called
+`bignumDevelopmentEnvironmentOs` to `linux`, `windows` or `mac` so that the gradle builds JVM and JS targets on your 
+platform. The reason for this switch is that most of the test are run on JVM by comparing results to Java BigInteger/Decimal
+so they should be run on your main development OS to verify proper results, and can be skipped on other operating systems
+where you are developing that platform specific features.
+
+And thank you for contributing!

--- a/bignum/build.gradle.kts
+++ b/bignum/build.gradle.kts
@@ -35,11 +35,34 @@ val sonatypePassword: String? by project
 
 val sonatypeUsername: String? by project
 
+enum class HostOs {
+    LINUX, WINDOWS, MAC
+}
+
+val bignumDevelopmentEnvironmentOs: String? by project
+
+val chosenDevelopmentEnviroment: HostOs = if (bignumDevelopmentEnvironmentOs != null) {
+    println("Selected dev OS: $bignumDevelopmentEnvironmentOs")
+    when (bignumDevelopmentEnvironmentOs) {
+        "linux" -> HostOs.LINUX
+        "windows" -> HostOs.WINDOWS
+        "mac" -> HostOs.MAC
+        else -> throw org.gradle.api.GradleException("Invalid development enviromoment OS selecte: " +
+                "$bignumDevelopmentEnvironmentOs. Only linux, windows and mac are supported at the moment")
+    }
+} else {
+    HostOs.LINUX
+}
+
 val sonatypePasswordEnv: String? = System.getenv()["SONATYPE_PASSWORD"]
 val sonatypeUsernameEnv: String? = System.getenv()["SONATYPE_USERNAME"]
 
 repositories {
     mavenCentral()
+    google()
+    maven("https://kotlin.bintray.com/kotlinx")
+    maven("https://dl.bintray.com/kotlin/kotlin-eap")
+    maven("https://dl.bintray.com/kotlin/kotlin-dev")
     jcenter()
 }
 group = "com.ionspin.kotlin"
@@ -47,29 +70,29 @@ version = "0.1.6-1.4.0-rc-SNAPSHOT"
 
 val ideaActive = System.getProperty("idea.active") == "true"
 
-fun getHostOsName(): String {
+fun getHostOsName(): HostOs {
     val target = System.getProperty("os.name")
-    if (target == "Linux") return "linux"
-    if (target.startsWith("Windows")) return "windows"
-    if (target.startsWith("Mac")) return "macos"
-    return "unknown"
+    if (target == "Linux") return HostOs.LINUX
+    if (target.startsWith("Windows")) return HostOs.WINDOWS
+    if (target.startsWith("Mac")) return HostOs.MAC
+    throw GradleException("Unknown OS: $target")
 }
 
 kotlin {
 
-    val hostOsName = getHostOsName()
-    println("Host os name $hostOsName")
+    val hostOs = getHostOsName()
+    println("Host os name $hostOs")
 
     if (ideaActive) {
-        when (hostOsName) {
-            "linux" -> linuxX64("native")
-            "macos" -> macosX64("native")
-            "windows" -> mingwX64("native")
+        when (hostOs) {
+            HostOs.LINUX -> linuxX64("native")
+            HostOs.MAC -> macosX64("native")
+            HostOs.WINDOWS -> mingwX64("native")
         }
     }
-
-    if (hostOsName == "linux") {
+    if (hostOs == chosenDevelopmentEnviroment) {
         jvm()
+
         js {
             compilations {
                 this.forEach {
@@ -93,6 +116,9 @@ kotlin {
                 }
             }
         }
+    }
+
+    if (hostOs == HostOs.LINUX) {
 
         linuxX64("linux") {
             binaries {
@@ -175,6 +201,7 @@ kotlin {
             dependencies {
                 implementation(kotlin(Deps.Common.test))
                 implementation(kotlin(Deps.Common.testAnnotation))
+                implementation(Deps.Common.coroutines)
             }
         }
 
@@ -192,22 +219,16 @@ kotlin {
         val nativeTest = if (ideaActive) {
             val nativeTest by getting {
                 dependsOn(commonTest)
-                dependencies {
-                    implementation(Deps.Native.coroutines)
-                }
             }
             nativeTest
         } else {
             val nativeTest by creating {
                 dependsOn(commonTest)
-                dependencies {
-                    implementation(Deps.Native.coroutines)
-                }
             }
             nativeTest
         }
 
-        if (hostOsName == "linux") {
+        if (hostOs == chosenDevelopmentEnviroment) {
             val jvmMain by getting {
                 dependencies {
                     implementation(kotlin(Deps.Jvm.stdLib))
@@ -215,12 +236,12 @@ kotlin {
             }
             val jvmTest by getting {
                 dependencies {
-                    implementation(Deps.Jvm.coroutinesCore)
                     implementation(kotlin(Deps.Jvm.test))
                     implementation(kotlin(Deps.Jvm.testJUnit))
                     implementation(kotlin(Deps.Jvm.reflection))
                 }
             }
+
             val jsMain by getting {
                 dependencies {
                     implementation(kotlin(Deps.Js.stdLib))
@@ -229,9 +250,11 @@ kotlin {
             val jsTest by getting {
                 dependencies {
                     implementation(kotlin(Deps.Js.test))
-                    implementation(Deps.Js.coroutines)
                 }
             }
+        }
+
+        if (hostOs == HostOs.LINUX) {
 
             val linuxMain by getting {
                 dependsOn(nativeMain)
@@ -322,21 +345,42 @@ tasks {
     val hostOsName = getHostOsName()
 
     create<Jar>("javadocJar") {
-        dependsOn(dokka)
+        dependsOn(dokkaJavadoc)
         archiveClassifier.set("javadoc")
-        from(dokka.get().outputDirectory)
+        from(dokkaJavadoc.get().outputDirectory)
     }
 
-    dokka {
+    dokkaJavadoc {
         println("Dokka !")
+        dokkaSourceSets {
+            create("commonMain") {
+                displayName = "common"
+                platform = "common"
+            }
+        }
     }
-    if (hostOsName == "linux") {
+    if (hostOsName == chosenDevelopmentEnviroment) {
         val jvmTest by getting(Test::class) {
             testLogging {
                 events("PASSED", "FAILED", "SKIPPED")
             }
         }
 
+        val jsNodeTest by getting(org.jetbrains.kotlin.gradle.targets.js.testing.KotlinJsTest::class) {
+            testLogging {
+                events("PASSED", "FAILED", "SKIPPED")
+            }
+        }
+
+        val jsBrowserTest by getting(org.jetbrains.kotlin.gradle.targets.js.testing.KotlinJsTest::class) {
+            testLogging {
+                events("PASSED", "FAILED", "SKIPPED")
+                showStandardStreams = true
+            }
+        }
+    }
+
+    if (hostOsName == HostOs.LINUX) {
         val linuxTest by getting(KotlinNativeTest::class) {
             testLogging {
                 events("PASSED", "FAILED", "SKIPPED")

--- a/bignum/build.gradle.kts
+++ b/bignum/build.gradle.kts
@@ -39,16 +39,16 @@ enum class HostOs {
     LINUX, WINDOWS, MAC
 }
 
-val bignumDevelopmentEnvironmentOs: String? by project
+val bignumPrimaryDevelopmentOs: String? by project
 
-val chosenDevelopmentEnviroment: HostOs = if (bignumDevelopmentEnvironmentOs != null) {
-    println("Selected dev OS: $bignumDevelopmentEnvironmentOs")
-    when (bignumDevelopmentEnvironmentOs) {
+val primaryDevelopmentOs: HostOs = if (bignumPrimaryDevelopmentOs != null) {
+    println("Selected dev OS: $bignumPrimaryDevelopmentOs")
+    when (bignumPrimaryDevelopmentOs) {
         "linux" -> HostOs.LINUX
         "windows" -> HostOs.WINDOWS
         "mac" -> HostOs.MAC
         else -> throw org.gradle.api.GradleException("Invalid development enviromoment OS selecte: " +
-                "$bignumDevelopmentEnvironmentOs. Only linux, windows and mac are supported at the moment")
+                "$bignumPrimaryDevelopmentOs. Only linux, windows and mac are supported at the moment")
     }
 } else {
     HostOs.LINUX
@@ -90,7 +90,7 @@ kotlin {
             HostOs.WINDOWS -> mingwX64("native")
         }
     }
-    if (hostOs == chosenDevelopmentEnviroment) {
+    if (hostOs == primaryDevelopmentOs) {
         jvm()
 
         js {
@@ -228,7 +228,7 @@ kotlin {
             nativeTest
         }
 
-        if (hostOs == chosenDevelopmentEnviroment) {
+        if (hostOs == primaryDevelopmentOs) {
             val jvmMain by getting {
                 dependencies {
                     implementation(kotlin(Deps.Jvm.stdLib))
@@ -359,7 +359,7 @@ tasks {
             }
         }
     }
-    if (hostOsName == chosenDevelopmentEnviroment) {
+    if (hostOsName == primaryDevelopmentOs) {
         val jvmTest by getting(Test::class) {
             testLogging {
                 events("PASSED", "FAILED", "SKIPPED")

--- a/buildSrc/src/main/kotlin/Deps.kt
+++ b/buildSrc/src/main/kotlin/Deps.kt
@@ -20,7 +20,7 @@ object Versions {
     val kotlin = "1.4.0-rc"
     val kotlinSerialization = "1.0-M1-1.4.0-rc"
     val nodePlugin = "1.3.0"
-    val dokkaPlugin = "0.11.0-dev-45"
+    val dokkaPlugin = "1.4.0-M3-dev-92"
 }
 
 object Deps {


### PR DESCRIPTION
Introduce support for `bignumDevelopmentEnvironmentOs` in `gradle.properties` in gradle home folder that defines local preferred development OS. If the preferred OS matches the current OS JVM and JS targets become enabled. This is usefull because full suite of JVM test take a long time to execute and should be run only on the main development OS and not waste time on other platforms.

Also bumped up dokka and updated to `dokkaJavadoc`

 This fixes #116 