### PR TITLE
First draft of fixes #111, fixes #118

### DIFF
--- a/bignum/build.gradle.kts
+++ b/bignum/build.gradle.kts
@@ -322,12 +322,12 @@ tasks {
     val hostOsName = getHostOsName()
 
     create<Jar>("javadocJar") {
-        dependsOn(dokka)
+        dependsOn(dokkaJavadoc)
         archiveClassifier.set("javadoc")
-        from(dokka.get().outputDirectory)
+        from(dokkaJavadoc.get().outputDirectory)
     }
 
-    dokka {
+    dokkaJavadoc {
         println("Dokka !")
     }
     if (hostOsName == "linux") {

--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/BigNumber.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/BigNumber.kt
@@ -123,6 +123,9 @@ interface BigNumber<BigType> where BigType : BigNumber<BigType> {
 
     fun signum(): Int
 
+    val isNegative get() = signum() < 0
+    val isPositive get() = signum() > 0
+
     /**
      * Return the number of decimal digits representing this number
      */

--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
@@ -1302,8 +1302,16 @@ class BigDecimal private constructor(
         return significand.ushortValue(exactRequired)
     }
 
+    /**
+     * Narrow to a float.
+     * @param exactRequired if false, precision can be lost. If true, the current absolute value
+     * must be between Float.MAX_VALUE and Float.MIN_VALUE, with 7 or less digits of precision.
+     * @throws ArithmeticException if exactRequired is true and any of the above conditions not met
+     */
     override fun floatValue(exactRequired: Boolean): Float {
-        if (exactRequired && (this.abs() > maximumFloat || this.abs() < leastSignificantFloat))
+        if (exactRequired && (this.abs() > maximumFloat
+                    || this.abs() < leastSignificantFloat)
+                    || this.precision > 7)
             throw ArithmeticException("Value cannot be narrowed to float")
 
         return if (exponent < 0 && exponent.absoluteValue < float10pow.size)
@@ -1316,8 +1324,16 @@ class BigDecimal private constructor(
         }
     }
 
+    /**
+     * Narrow to a double.
+     * @param exactRequired if false, precision can be lost. If true, the current absolute value
+     * must be between Double.MAX_VALUE and Double.MIN_VALUE, with 16 or less digits of precision.
+     * @throws ArithmeticException if exactRequired is true and any of the above conditions not met
+     */
     override fun doubleValue(exactRequired: Boolean): Double {
-        if (exactRequired && (this.abs() > maximumDouble || this.abs() < leastSignificantDouble))
+        if (exactRequired && (this.abs() > maximumDouble
+                    || this.abs() < leastSignificantDouble)
+                    || this.precision > 16)
             throw ArithmeticException("Value cannot be narrowed to double")
 
         /*

--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
@@ -1313,7 +1313,7 @@ class BigDecimal private constructor(
     /**
      * @return true if "this" is a whole number, false if not
      */
-    fun isWholeNumber():Boolean {
+    fun isWholeNumber(): Boolean {
         return abs().divrem(ONE).second.isZero()
     }
     /**
@@ -1333,9 +1333,9 @@ class BigDecimal private constructor(
      * @throws ArithmeticException if exactRequired is true and any of the above conditions not met
      */
     override fun floatValue(exactRequired: Boolean): Float {
-        if (exactRequired && (this.abs() > maximumFloat
-                    || this.abs() < leastSignificantFloat)
-                    || this.precision > 8)
+        if (exactRequired && (this.abs() > maximumFloat ||
+                    this.abs() < leastSignificantFloat) ||
+                    this.precision > 8)
             throw ArithmeticException("Value cannot be narrowed to float")
 
         return if (exponent < 0 && exponent.absoluteValue < float10pow.size)
@@ -1343,7 +1343,7 @@ class BigDecimal private constructor(
         else {
             if (exponent >= 0 && exponent < float10pow.size) {
                 this.significand.longValue(true).toFloat() / float10pow[exponent.toInt()]
-            }else
+            } else
                 this.toString().toFloat()
         }
     }
@@ -1355,9 +1355,9 @@ class BigDecimal private constructor(
      * @throws ArithmeticException if exactRequired is true and any of the above conditions not met
      */
     override fun doubleValue(exactRequired: Boolean): Double {
-        if (exactRequired && (this.abs() > maximumDouble
-                    || this.abs() < leastSignificantDouble)
-                    || this.precision > 17)
+        if (exactRequired && (this.abs() > maximumDouble ||
+                    this.abs() < leastSignificantDouble) ||
+                    this.precision > 17)
             throw ArithmeticException("Value cannot be narrowed to double")
 
         /*
@@ -1371,7 +1371,7 @@ class BigDecimal private constructor(
         else {
             if (exponent >= 0 && exponent < double10pow.size) {
                 this.significand.longValue(true).toDouble() / double10pow[exponent.toInt()]
-            }else
+            } else
                 this.toString().toDouble()
         }
     }

--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
@@ -19,6 +19,7 @@ package com.ionspin.kotlin.bignum.decimal
 
 import com.ionspin.kotlin.bignum.BigNumber
 import com.ionspin.kotlin.bignum.CommonBigNumberOperations
+import com.ionspin.kotlin.bignum.NarrowingOperations
 import com.ionspin.kotlin.bignum.integer.BigInteger
 import com.ionspin.kotlin.bignum.integer.ComparisonWorkaround
 import com.ionspin.kotlin.bignum.integer.Sign
@@ -46,6 +47,7 @@ class BigDecimal private constructor(
     val decimalMode: DecimalMode? = null
 ) : BigNumber<BigDecimal>,
     CommonBigNumberOperations<BigDecimal>,
+    NarrowingOperations<BigDecimal>,
     Comparable<Any> {
 
     val precision = significand.numberOfDecimalDigits()
@@ -245,7 +247,7 @@ class BigDecimal private constructor(
          *
          * i.e. 7111 -> 7.111E+3
          *
-         * @param long Long value to conver
+         * @param bigInteger Long value to conver
          * @return BigDecimal representing input
          */
         fun fromBigInteger(bigInteger: BigInteger, decimalMode: DecimalMode? = null): BigDecimal {
@@ -272,7 +274,7 @@ class BigDecimal private constructor(
          *
          * i.e. 7111 -> 7.111E+3
          *
-         * @param long Long value to conver
+         * @param uLong Long value to conver
          * @return BigDecimal representing input
          */
         fun fromULong(uLong: ULong, decimalMode: DecimalMode? = null): BigDecimal {
@@ -298,7 +300,7 @@ class BigDecimal private constructor(
          *
          * i.e. 7111 -> 7.111E+3
          *
-         * @param int Int value to conver
+         * @param uInt Int value to conver
          * @return BigDecimal representing input
          */
         fun fromUInt(uInt: UInt, decimalMode: DecimalMode? = null): BigDecimal {
@@ -311,7 +313,7 @@ class BigDecimal private constructor(
          *
          * i.e. 7111 -> 7.111E+3
          *
-         * @param short Short value to conver
+         * @param uShort Short value to conver
          * @return BigDecimal representing input
          */
         fun fromUShort(uShort: UShort, decimalMode: DecimalMode? = null): BigDecimal {
@@ -337,7 +339,7 @@ class BigDecimal private constructor(
          *
          * i.e. 11 -> 1.1E+2
          *
-         * @param byte Byte value to conver
+         * @param uByte Byte value to conver
          * @return BigDecimal representing input
          */
         fun fromUByte(uByte: UByte, decimalMode: DecimalMode? = null): BigDecimal {
@@ -396,7 +398,7 @@ class BigDecimal private constructor(
          *
          * i.e. 7111 -> 7.111E+0
          *
-         * @param short Short value to conver
+         * @param byte Short value to convert
          * @return BigDecimal representing input
          */
         fun fromByteAsSignificand(byte: Byte, decimalMode: DecimalMode? = null) =
@@ -496,7 +498,7 @@ class BigDecimal private constructor(
          *
          * i.e. 7111 -> 7.111E+0
          *
-         * @param long Long value to conver
+         * @param bigInteger Long value to conver
          * @return BigDecimal representing input
          */
         override fun fromBigInteger(bigInteger: BigInteger): BigDecimal {
@@ -508,7 +510,7 @@ class BigDecimal private constructor(
          *
          * i.e. 7111 -> 7.111E+0
          *
-         * @param long Long value to conver
+         * @param uLong Long value to conver
          * @return BigDecimal representing input
          */
         override fun fromULong(uLong: ULong): BigDecimal {
@@ -520,7 +522,7 @@ class BigDecimal private constructor(
          *
          * i.e. 7111 -> 7.111E+0
          *
-         * @param int Int value to conver
+         * @param uInt Int value to conver
          * @return BigDecimal representing input
          */
         override fun fromUInt(uInt: UInt): BigDecimal {
@@ -532,7 +534,7 @@ class BigDecimal private constructor(
          *
          * i.e. 7111 -> 7.111E+0
          *
-         * @param short Short value to conver
+         * @param uShort Short value to conver
          * @return BigDecimal representing input
          */
         override fun fromUShort(uShort: UShort): BigDecimal {
@@ -544,7 +546,7 @@ class BigDecimal private constructor(
          *
          * i.e. 7111 -> 7.111E+0
          *
-         * @param short Short value to conver
+         * @param uByte Short value to conver
          * @return BigDecimal representing input
          */
         override fun fromUByte(uByte: UByte): BigDecimal {
@@ -592,7 +594,7 @@ class BigDecimal private constructor(
          *
          * i.e. 7111 -> 7.111E+0
          *
-         * @param short Short value to conver
+         * @param byte Short value to conver
          * @return BigDecimal representing input
          */
         override fun fromByte(byte: Byte): BigDecimal {
@@ -731,7 +733,7 @@ class BigDecimal private constructor(
                             val leftTruncated = left.substring(leftFirstNonZero, left.length)
                             val rightTruncated = right.substring(0, rightLastNonZero + 1)
                             var significand = BigInteger.parseString(leftTruncated + rightTruncated, 10)
-                            var exponent = if (leftTruncated.length >= 1 && leftTruncated[0] != '0') {
+                            val exponent = if (leftTruncated.length >= 1 && leftTruncated[0] != '0') {
                                 leftTruncated.length - 1
                             } else {
                                 (rightTruncated.indexOfFirst { it != '0' } + 1) * -1
@@ -931,8 +933,8 @@ class BigDecimal private constructor(
             else -> this.significand
         }
 
-        var divRem = thisPrepared divrem other.significand
-        var result = divRem.quotient
+        val divRem = thisPrepared divrem other.significand
+        val result = divRem.quotient
         if (result == BigInteger.ZERO) {
             newExponent--
         }
@@ -1090,7 +1092,7 @@ class BigDecimal private constructor(
      */
     override fun numberOfDecimalDigits(): Long {
         val numberOfDigits = when {
-            exponent > 0 && exponent < precision -> precision
+            exponent in 1 until precision -> precision
             exponent > 0 && exponent > precision -> exponent + 1 // Significand is already 10^1 when exponent is > 0
             exponent > 0 && exponent == precision -> precision + 1 // Same as above
             exponent < 0 -> exponent.absoluteValue + precision
@@ -1209,13 +1211,13 @@ class BigDecimal private constructor(
         return when {
             exponent > 0 -> {
                 for (i in 0 until exponent - 1) {
-                    result = result * this
+                    result *= this
                 }
                 result
             }
             exponent < 0 -> {
                 for (i in 0..exponent.absoluteValue) {
-                    result = result / this
+                    result /= this
                 }
                 result
             }
@@ -1230,6 +1232,107 @@ class BigDecimal private constructor(
      * @return Result of signum function for this BigDecimal (-1 negative, 0 zero, 1 positive)
      */
     override fun signum(): Int = significand.signum()
+
+    /**
+     * The next group of functions are implementations of the NarrowingOperations interface
+     */
+    /**
+     * Convert the current value to  Int.
+     * @param exactRequired True causes an ArithmeticException to be thrown if there is any loss of
+     * precision during the conversion, either side of the decimal. False truncates any precision to
+     * the right of the decimal.
+     */
+    override fun intValue(exactRequired: Boolean): Int {
+        return significand.intValue(exactRequired)
+    }
+
+    override fun longValue(exactRequired: Boolean): Long {
+        return significand.longValue(exactRequired)
+    }
+
+    override fun byteValue(exactRequired: Boolean): Byte {
+        return significand.byteValue(exactRequired)
+    }
+
+    override fun shortValue(exactRequired: Boolean): Short {
+        return significand.shortValue(exactRequired)
+    }
+
+    override fun uintValue(exactRequired: Boolean): UInt {
+        return significand.uintValue(exactRequired)
+    }
+
+    override fun ulongValue(exactRequired: Boolean): ULong {
+        return significand.ulongValue(exactRequired)
+    }
+
+    override fun ubyteValue(exactRequired: Boolean): UByte {
+        return significand.ubyteValue(exactRequired)
+    }
+
+    override fun ushortValue(exactRequired: Boolean): UShort {
+        return significand.ushortValue(exactRequired)
+    }
+
+    override fun floatValue(exactRequired: Boolean): Float {
+        val maxExponent = 1L shl 8
+        if (exactRequired) {
+            if (exponent.absoluteValue > maxExponent)
+                throw ArithmeticException("exponent cannot be Narrowed to float")
+            if (precision > 23)
+                throw ArithmeticException("Narrowing to float would lose precision")
+        }
+
+        /**
+         * Powers of 10 which can be represented exactly in {@code
+         * float}.
+         */
+        val float10pow = floatArrayOf(
+            1.0e0f, 1.0e1f, 1.0e2f, 1.0e3f, 1.0e4f, 1.0e5f,
+            1.0e6f, 1.0e7f, 1.0e8f, 1.0e9f, 1.0e10f)
+        return if (exponent < 0 && exponent.absoluteValue < float10pow.size)
+            toBigInteger().longValue() * float10pow[exponent.absoluteValue.toInt()]
+        else {
+            if (exponent >= 0 && exponent < float10pow.size) {
+                this.significand.longValue(true).toFloat() / float10pow[exponent.toInt()]
+            }else
+                this.toString().toFloat()
+        }
+    }
+
+    override fun doubleValue(exactRequired: Boolean): Double {
+        if (exactRequired) {
+            if (exponent.absoluteValue > 1L shl 11)
+                throw ArithmeticException("exponent cannot be Narrowed to double")
+            if (precision > 52 || significand.numberOfWords > 1)
+                throw ArithmeticException("Narrowing to double would lose precision")
+        }
+
+        /**
+         * Powers of 10 which can be represented exactly in `double`. From java BigDecimal, hopefully
+         * significantly more efficient for most conversions than toStrings.
+         */
+        val double10pow = doubleArrayOf(
+            1.0e0, 1.0e1, 1.0e2, 1.0e3, 1.0e4, 1.0e5,
+            1.0e6, 1.0e7, 1.0e8, 1.0e9, 1.0e10, 1.0e11,
+            1.0e12, 1.0e13, 1.0e14, 1.0e15, 1.0e16, 1.0e17,
+            1.0e18, 1.0e19, 1.0e20, 1.0e21, 1.0e22
+        )
+        /*
+         * Since the significand  can be exactly
+         * represented as double value, and the exponent perform a single
+         * double multiply or divide to compute the (properly
+         * rounded) result.  For large exponent values, use fallback string parse
+         */
+        return if (exponent < 0 && exponent.absoluteValue < double10pow.size)
+            toBigInteger().longValue() * double10pow[exponent.absoluteValue.toInt()]
+        else {
+            if (exponent >= 0 && exponent < double10pow.size) {
+                this.significand.longValue(true).toDouble() / double10pow[exponent.toInt()]
+            }else
+                this.toString().toDouble()
+        }
+    }
 
     /**
      * Round using specific [DecimalMode] and return rounded instance. This is applied only to significand.
@@ -1379,12 +1482,12 @@ class BigDecimal private constructor(
         }
         return when (other) {
             is BigDecimal -> compare(other)
-            is Long -> compare(BigDecimal.fromLong(other))
-            is Int -> compare(BigDecimal.fromInt(other))
-            is Short -> compare(BigDecimal.fromShort(other))
-            is Byte -> compare(BigDecimal.fromByte(other))
-            is Double -> compare(BigDecimal.fromDouble(other))
-            is Float -> compare(BigDecimal.fromFloat(other))
+            is Long -> compare(fromLong(other))
+            is Int -> compare(fromInt(other))
+            is Short -> compare(fromShort(other))
+            is Byte -> compare(fromByte(other))
+            is Double -> compare(fromDouble(other))
+            is Float -> compare(fromFloat(other))
             else -> throw RuntimeException("Invalid comparison type for BigDecimal: ${other::class.simpleName}")
         }
     }
@@ -1396,7 +1499,7 @@ class BigDecimal private constructor(
     private fun javascriptNumberComparison(number: Number): Int {
         val float = number.toFloat()
         return when {
-            float % 1 == 0f -> compare(BigDecimal.fromLong(number.toLong()))
+            float % 1 == 0f -> compare(fromLong(number.toLong()))
             else -> compare(number.toFloat().toBigDecimal())
         }
     }
@@ -1404,12 +1507,12 @@ class BigDecimal private constructor(
     override fun equals(other: Any?): Boolean {
         val comparison = when (other) {
             is BigDecimal -> compare(other)
-            is Long -> compare(BigDecimal.fromLong(other))
-            is Int -> compare(BigDecimal.fromInt(other))
-            is Short -> compare(BigDecimal.fromShort(other))
-            is Byte -> compare(BigDecimal.fromByte(other))
-            is Double -> compare(BigDecimal.fromDouble(other))
-            is Float -> compare(BigDecimal.fromFloat(other))
+            is Long -> compare(fromLong(other))
+            is Int -> compare(fromInt(other))
+            is Short -> compare(fromShort(other))
+            is Byte -> compare(fromByte(other))
+            is Double -> compare(fromDouble(other))
+            is Float -> compare(fromFloat(other))
             else -> -1
         }
         return comparison == 0
@@ -1424,7 +1527,7 @@ class BigDecimal private constructor(
      * i.e. 1.23E+9
      */
     override fun toString(): String {
-        if (BigDecimal.useToStringExpanded) {
+        if (useToStringExpanded) {
             return toStringExpanded()
         }
         val significandString = significand.toString(10)
@@ -1524,20 +1627,19 @@ class BigDecimal private constructor(
 
         val prefix = input.substring(0 until input.length - position)
         val suffix = input.substring(input.length - position until input.length)
-        val prepared = if (suffix.isNotEmpty()) {
-            (prefix + '.' + suffix).dropLastWhile { it == '0' }
+
+        return if (suffix.isNotEmpty()) {
+            ("$prefix.$suffix").dropLastWhile { it == '0' }
         } else {
             prefix
         }
-
-        return prepared
     }
 
     private fun placeADotInString(input: String, position: Int): String {
 
         val prefix = input.substring(0 until input.length - position)
         val suffix = input.substring(input.length - position until input.length)
-        val prepared = prefix + '.' + suffix
+        val prepared = "$prefix.$suffix"
 
         return prepared.dropLastWhile { it == '0' }
     }

--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
@@ -1271,35 +1271,59 @@ class BigDecimal private constructor(
      * the right of the decimal.
      */
     override fun intValue(exactRequired: Boolean): Int {
-        return significand.intValue(exactRequired)
+        checkWholeness(exactRequired)
+        return toBigInteger().intValue(exactRequired)
     }
 
     override fun longValue(exactRequired: Boolean): Long {
-        return significand.longValue(exactRequired)
+        checkWholeness(exactRequired)
+        return toBigInteger().longValue(exactRequired)
     }
 
     override fun byteValue(exactRequired: Boolean): Byte {
-        return significand.byteValue(exactRequired)
+        checkWholeness(exactRequired)
+        return toBigInteger().byteValue(exactRequired)
     }
 
     override fun shortValue(exactRequired: Boolean): Short {
-        return significand.shortValue(exactRequired)
+        checkWholeness(exactRequired)
+        return toBigInteger().shortValue(exactRequired)
     }
 
     override fun uintValue(exactRequired: Boolean): UInt {
-        return significand.uintValue(exactRequired)
+        checkWholeness(exactRequired)
+        return toBigInteger().uintValue(exactRequired)
     }
 
     override fun ulongValue(exactRequired: Boolean): ULong {
-        return significand.ulongValue(exactRequired)
+        checkWholeness(exactRequired)
+        return toBigInteger().ulongValue(exactRequired)
     }
 
     override fun ubyteValue(exactRequired: Boolean): UByte {
-        return significand.ubyteValue(exactRequired)
+        checkWholeness(exactRequired)
+        return toBigInteger().ubyteValue(exactRequired)
     }
 
     override fun ushortValue(exactRequired: Boolean): UShort {
-        return significand.ushortValue(exactRequired)
+        checkWholeness(exactRequired)
+        return toBigInteger().ushortValue(exactRequired)
+    }
+
+    /**
+     * @return true if "this" is a whole number, false if not
+     */
+    fun isWholeNumber():Boolean {
+        return abs().divrem(ONE).second.isZero()
+    }
+    /**
+     * @param exactRequired if not a whole number, throw an exception
+     * @return true if this is a whole number, false if not
+     * @throws ArithmeticException if any nonzero value to the right of the decimal
+     */
+    private fun checkWholeness(exactRequired: Boolean) {
+        if (exactRequired && !isWholeNumber())
+            throw ArithmeticException("Cannot convert to int and provide exact value")
     }
 
     /**
@@ -1311,7 +1335,7 @@ class BigDecimal private constructor(
     override fun floatValue(exactRequired: Boolean): Float {
         if (exactRequired && (this.abs() > maximumFloat
                     || this.abs() < leastSignificantFloat)
-                    || this.precision > 7)
+                    || this.precision > 8)
             throw ArithmeticException("Value cannot be narrowed to float")
 
         return if (exponent < 0 && exponent.absoluteValue < float10pow.size)
@@ -1333,7 +1357,7 @@ class BigDecimal private constructor(
     override fun doubleValue(exactRequired: Boolean): Double {
         if (exactRequired && (this.abs() > maximumDouble
                     || this.abs() < leastSignificantDouble)
-                    || this.precision > 16)
+                    || this.precision > 17)
             throw ArithmeticException("Value cannot be narrowed to double")
 
         /*

--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/DecimalMode.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/DecimalMode.kt
@@ -77,6 +77,8 @@ enum class RoundingMode {
  */
 data class DecimalMode(val decimalPrecision: Long = 0, val roundingMode: RoundingMode = RoundingMode.NONE) {
 
+    val isPrecisionUnlimited = decimalPrecision == 0L
+
     init {
         if (decimalPrecision == 0L && roundingMode != RoundingMode.NONE) {
             throw ArithmeticException("Rounding mode with 0 digits precision.")

--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/integer/BigInteger.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/integer/BigInteger.kt
@@ -707,14 +707,14 @@ class BigInteger internal constructor(wordArray: WordArray, val sign: Sign) : Bi
     }
 
     override fun intValue(exactRequired: Boolean): Int {
-        if (exactRequired && this.abs() > Int.MAX_VALUE.toUInt()) {
+        if (exactRequired && (this > Int.MAX_VALUE || this < Int.MIN_VALUE)) {
             throw ArithmeticException("Cannot convert to int and provide exact value")
         }
         return magnitude[0].toInt() * signum()
     }
 
     override fun longValue(exactRequired: Boolean): Long {
-        if (exactRequired && (this.abs() > Long.MAX_VALUE.toULong())) {
+        if (exactRequired && (this > Long.MAX_VALUE || this < Long.MIN_VALUE)) {
             throw ArithmeticException("Cannot convert to long and provide exact value")
         }
         return if (magnitude.size > 1) {
@@ -726,28 +726,28 @@ class BigInteger internal constructor(wordArray: WordArray, val sign: Sign) : Bi
     }
 
     override fun byteValue(exactRequired: Boolean): Byte {
-        if (exactRequired && this.abs() > Byte.MAX_VALUE.toUInt()) {
+        if (exactRequired && (this > Byte.MAX_VALUE || this < Byte.MIN_VALUE)) {
             throw ArithmeticException("Cannot convert to byte and provide exact value")
         }
         return (magnitude[0].toByte() * signum()).toByte()
     }
 
     override fun shortValue(exactRequired: Boolean): Short {
-        if (exactRequired && this.abs() > Short.MAX_VALUE.toUInt()) {
+        if (exactRequired && (this > Short.MAX_VALUE || this < Short.MIN_VALUE)) {
             throw ArithmeticException("Cannot convert to short and provide exact value")
         }
         return (magnitude[0].toShort() * signum()).toShort()
     }
 
     override fun uintValue(exactRequired: Boolean): UInt {
-        if (exactRequired && this.abs() > UInt.MAX_VALUE) {
+        if (exactRequired && (this > UInt.MAX_VALUE || isNegative)) {
             throw ArithmeticException("Cannot convert to unsigned int and provide exact value")
         }
         return magnitude[0].toUInt()
     }
 
     override fun ulongValue(exactRequired: Boolean): ULong {
-        if (exactRequired && (this.abs() > ULong.MAX_VALUE)) {
+        if (exactRequired && (this > ULong.MAX_VALUE || isNegative)) {
             throw ArithmeticException("Cannot convert to unsigned long and provide exact value")
         }
         return if (magnitude.size > 1) {
@@ -759,14 +759,14 @@ class BigInteger internal constructor(wordArray: WordArray, val sign: Sign) : Bi
     }
 
     override fun ubyteValue(exactRequired: Boolean): UByte {
-        if (exactRequired && this.abs() > UByte.MAX_VALUE.toUInt()) {
+        if (exactRequired && (this > UByte.MAX_VALUE.toUInt() || isNegative)) {
             throw ArithmeticException("Cannot convert to unsigned byte and provide exact value")
         }
         return magnitude[0].toUByte()
     }
 
     override fun ushortValue(exactRequired: Boolean): UShort {
-        if (exactRequired && this.abs() > UShort.MAX_VALUE.toUInt()) {
+        if (exactRequired && this > UShort.MAX_VALUE.toUInt() || isNegative) {
             throw ArithmeticException("Cannot convert to unsigned short and provide exact value")
         }
         return magnitude[0].toUShort()

--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/integer/BigInteger.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/integer/BigInteger.kt
@@ -707,14 +707,14 @@ class BigInteger internal constructor(wordArray: WordArray, val sign: Sign) : Bi
     }
 
     override fun intValue(exactRequired: Boolean): Int {
-        if (exactRequired && this > Int.MAX_VALUE.toUInt()) {
+        if (exactRequired && this.abs() > Int.MAX_VALUE.toUInt()) {
             throw ArithmeticException("Cannot convert to int and provide exact value")
         }
         return magnitude[0].toInt() * signum()
     }
 
     override fun longValue(exactRequired: Boolean): Long {
-        if (exactRequired && (this > Long.MAX_VALUE.toULong())) {
+        if (exactRequired && (this.abs() > Long.MAX_VALUE.toULong())) {
             throw ArithmeticException("Cannot convert to long and provide exact value")
         }
         return if (magnitude.size > 1) {
@@ -726,28 +726,28 @@ class BigInteger internal constructor(wordArray: WordArray, val sign: Sign) : Bi
     }
 
     override fun byteValue(exactRequired: Boolean): Byte {
-        if (exactRequired && this > Byte.MAX_VALUE.toUInt()) {
+        if (exactRequired && this.abs() > Byte.MAX_VALUE.toUInt()) {
             throw ArithmeticException("Cannot convert to byte and provide exact value")
         }
         return (magnitude[0].toByte() * signum()).toByte()
     }
 
     override fun shortValue(exactRequired: Boolean): Short {
-        if (exactRequired && this > Short.MAX_VALUE.toUInt()) {
+        if (exactRequired && this.abs() > Short.MAX_VALUE.toUInt()) {
             throw ArithmeticException("Cannot convert to short and provide exact value")
         }
         return (magnitude[0].toShort() * signum()).toShort()
     }
 
     override fun uintValue(exactRequired: Boolean): UInt {
-        if (exactRequired && this > UInt.MAX_VALUE) {
+        if (exactRequired && this.abs() > UInt.MAX_VALUE) {
             throw ArithmeticException("Cannot convert to unsigned int and provide exact value")
         }
         return magnitude[0].toUInt()
     }
 
     override fun ulongValue(exactRequired: Boolean): ULong {
-        if (exactRequired && (this > ULong.MAX_VALUE)) {
+        if (exactRequired && (this.abs() > ULong.MAX_VALUE)) {
             throw ArithmeticException("Cannot convert to unsigned long and provide exact value")
         }
         return if (magnitude.size > 1) {
@@ -759,28 +759,28 @@ class BigInteger internal constructor(wordArray: WordArray, val sign: Sign) : Bi
     }
 
     override fun ubyteValue(exactRequired: Boolean): UByte {
-        if (exactRequired && this > UByte.MAX_VALUE.toUInt()) {
+        if (exactRequired && this.abs() > UByte.MAX_VALUE.toUInt()) {
             throw ArithmeticException("Cannot convert to unsigned byte and provide exact value")
         }
         return magnitude[0].toUByte()
     }
 
     override fun ushortValue(exactRequired: Boolean): UShort {
-        if (exactRequired && this > UShort.MAX_VALUE.toUInt()) {
+        if (exactRequired && this.abs() > UShort.MAX_VALUE.toUInt()) {
             throw ArithmeticException("Cannot convert to unsigned short and provide exact value")
         }
         return magnitude[0].toUShort()
     }
 
     override fun floatValue(exactRequired: Boolean): Float {
-        if (exactRequired && this > Float.MAX_VALUE) {
+        if (exactRequired && this.abs() > Float.MAX_VALUE) {
             throw ArithmeticException("Cannot convert to float and provide exact value")
         }
         return this.toString().toFloat()
     }
 
     override fun doubleValue(exactRequired: Boolean): Double {
-        if (exactRequired && this > Double.MAX_VALUE) {
+        if (exactRequired && this.abs() > Double.MAX_VALUE) {
             throw ArithmeticException("Cannot convert to float and provide exact value")
         }
         return this.toString().toDouble()

--- a/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalNarrowingTest.kt
+++ b/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalNarrowingTest.kt
@@ -1,0 +1,57 @@
+/*
+ *    Copyright 2019 Ugljesa Jovanovic
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ *
+ */
+
+package com.ionspin.kotlin.bignum.decimal
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * Created by Ugljesa Jovanovic
+ * ugljesa.jovanovic@ionspin.com
+ * on 9-Aug-2020
+ */
+
+class BigDecimalNarrowingTest {
+
+    @Test
+    fun doubleValueTest() {
+        var dub = BigDecimal.fromDouble(Double.MAX_VALUE)
+        assertEquals(Double.MAX_VALUE, dub.doubleValue(true))
+        dub = BigDecimal.fromDouble(-Double.MAX_VALUE)
+        assertEquals(-Double.MAX_VALUE, dub.doubleValue(true))
+        dub = BigDecimal.fromDouble(Double.MIN_VALUE)
+        assertEquals(Double.MIN_VALUE, dub.doubleValue(true))
+        assertFailsWith<ArithmeticException> {
+            dub.divide(BigDecimal.TEN).doubleValue(true)
+        }
+    }
+
+    @Test
+    fun floatValueTest() {
+        var f = BigDecimal.fromFloat(Float.MAX_VALUE)
+        assertEquals(Float.MAX_VALUE, f.floatValue(true))
+        f = BigDecimal.fromFloat(-Float.MAX_VALUE)
+        assertEquals(-Float.MAX_VALUE, f.floatValue(true))
+        f = BigDecimal.fromFloat(Float.MIN_VALUE)
+        assertEquals(Float.MIN_VALUE, f.floatValue(true))
+        assertFailsWith<ArithmeticException> {
+            f.divide(BigDecimal.TEN).floatValue(true)
+        }
+    }
+}

--- a/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalNarrowingTest.kt
+++ b/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalNarrowingTest.kt
@@ -231,4 +231,20 @@ class JvmBigDecimalNarrowingTest {
         }
         assertEquals(12.toULong(), f.ulongValue())
     }
+
+    @Test
+    fun signCheckTest() {
+        val x = BigDecimal.fromInt(123456)
+        assertTrue(!x.isNegative)
+        assertTrue(x.isPositive)
+        assertTrue(x.signum() > 0)
+        val x1 = x.negate()
+        assertTrue(x1.isNegative)
+        assertTrue(!x1.isPositive)
+        assertTrue(x1.signum() < 0)
+        val zero = BigDecimal.ZERO
+        assertTrue(!zero.isPositive)
+        assertTrue(!zero.isNegative)
+        assertTrue(zero.isZero())
+    }
 }

--- a/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalNarrowingTest.kt
+++ b/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalNarrowingTest.kt
@@ -1,9 +1,9 @@
 package com.ionspin.kotlin.bignum.decimal
 
-import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
+import org.junit.Test
 
 /**
  * Unit tests (JVM for easy debugging) on Narrowing functionality for BigDecimal.  Short, Int,

--- a/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalNarrowingTest.kt
+++ b/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalNarrowingTest.kt
@@ -11,6 +11,7 @@ import kotlin.test.assertTrue
  * and Double are a little different, but test similar edges.
  */
 class JvmBigDecimalNarrowingTest {
+    val someFloatValue = 12.12F
 
     @Test
     fun divideRoundingTest() {
@@ -88,6 +89,27 @@ class JvmBigDecimalNarrowingTest {
     }
 
     @Test
+    fun byteValueTest() {
+        val i = BigDecimal.fromByte(Byte.MAX_VALUE)
+        assertEquals(Byte.MAX_VALUE, i.byteValue())
+        assertFailsWith<ArithmeticException> {
+            i.plus(BigDecimal.ONE).byteValue(true)
+        }
+
+        val iN = BigDecimal.fromByte(Byte.MIN_VALUE)
+        assertEquals(Byte.MIN_VALUE, iN.byteValue())
+        assertFailsWith<ArithmeticException> {
+            iN.minus(BigDecimal.ONE).byteValue(true)
+        }
+
+        val f = BigDecimal.fromFloat(someFloatValue)
+        assertFailsWith<ArithmeticException> {
+            f.byteValue(true)
+        }
+        assertEquals(12, f.byteValue())
+    }
+
+    @Test
     fun shortValueTest() {
         val i = BigDecimal.fromShort(Short.MAX_VALUE)
         assertEquals(Short.MAX_VALUE, i.shortValue())
@@ -100,6 +122,12 @@ class JvmBigDecimalNarrowingTest {
         assertFailsWith<ArithmeticException> {
             iN.minus(BigDecimal.ONE).shortValue(true)
         }
+
+        val f = BigDecimal.fromFloat(someFloatValue)
+        assertFailsWith<ArithmeticException> {
+            f.shortValue(true)
+        }
+        assertEquals(12, f.shortValue())
     }
 
     @Test
@@ -115,6 +143,12 @@ class JvmBigDecimalNarrowingTest {
         assertFailsWith<ArithmeticException> {
             iN.minus(BigDecimal.ONE).intValue(true)
         }
+
+        val f = BigDecimal.fromFloat(someFloatValue)
+        assertFailsWith<ArithmeticException> {
+            f.intValue(true)
+        }
+        assertEquals(12, f.intValue())
     }
 
     @Test
@@ -125,11 +159,76 @@ class JvmBigDecimalNarrowingTest {
             i.plus(BigDecimal.ONE).longValue(true)
         }
 
-        // kludge this for now because BigInteger longValue has error when MIN_VALUE is set
-        val iN = BigDecimal.fromLong(Long.MIN_VALUE + 1)
-        assertEquals(Long.MIN_VALUE+1, iN.longValue())
+        val iN = BigDecimal.fromLong(Long.MIN_VALUE)
+        assertEquals(Long.MIN_VALUE, iN.longValue())
         assertFailsWith<ArithmeticException> {
-            iN.minus(BigDecimal.ONE).minus(BigDecimal.ONE).longValue(true)
+            iN.minus(BigDecimal.ONE).longValue(true)
         }
+
+        val f = BigDecimal.fromFloat(someFloatValue)
+        assertFailsWith<ArithmeticException> {
+            f.longValue(true)
+        }
+        assertEquals(12L, f.longValue())
+    }
+
+    @Test
+    fun ubyteValueTest() {
+        val i = BigDecimal.fromUByte(UByte.MAX_VALUE)
+        assertEquals(UByte.MAX_VALUE, i.ubyteValue())
+        assertFailsWith<ArithmeticException> {
+            i.plus(BigDecimal.ONE).ubyteValue(true)
+        }
+
+        val f = BigDecimal.fromFloat(someFloatValue)
+        assertFailsWith<ArithmeticException> {
+            f.ubyteValue(true)
+        }
+        assertEquals(12.toUByte(), f.ubyteValue())
+    }
+
+    @Test
+    fun ushortValueTest() {
+        val i = BigDecimal.fromUShort(UShort.MAX_VALUE)
+        assertEquals(UShort.MAX_VALUE, i.ushortValue())
+        assertFailsWith<ArithmeticException> {
+            i.plus(BigDecimal.ONE).ushortValue(true)
+        }
+
+        val f = BigDecimal.fromFloat(someFloatValue)
+        assertFailsWith<ArithmeticException> {
+            f.ushortValue(true)
+        }
+        assertEquals(12.toUShort(), f.ushortValue())
+    }
+
+    @Test
+    fun uintValueTest() {
+        val i = BigDecimal.fromUInt(UInt.MAX_VALUE)
+        assertEquals(UInt.MAX_VALUE, i.uintValue())
+        assertFailsWith<ArithmeticException> {
+            i.plus(BigDecimal.ONE).uintValue(true)
+        }
+
+        val f = BigDecimal.fromFloat(someFloatValue)
+        assertFailsWith<ArithmeticException> {
+            f.uintValue(true)
+        }
+        assertEquals(12.toUInt(), f.uintValue())
+    }
+
+    @Test
+    fun ulongValueTest() {
+        val i = BigDecimal.fromULong(ULong.MAX_VALUE)
+        assertEquals(ULong.MAX_VALUE, i.ulongValue())
+        assertFailsWith<ArithmeticException> {
+            i.plus(BigDecimal.ONE).ulongValue(true)
+        }
+
+        val f = BigDecimal.fromFloat(someFloatValue)
+        assertFailsWith<ArithmeticException> {
+            f.ulongValue(true)
+        }
+        assertEquals(12.toULong(), f.ulongValue())
     }
 }

--- a/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalNarrowingTest.kt
+++ b/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalNarrowingTest.kt
@@ -3,8 +3,19 @@ package com.ionspin.kotlin.bignum.decimal
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 class JvmBigDecimalNarrowingTest {
+
+    @Test
+    fun divideRoundingTest() {
+        val dub = BigDecimal.fromDouble(Double.MIN_VALUE)
+        val dub2 = dub.divide(BigDecimal.TEN)
+        assertTrue(dub2 < dub)
+        val dub3 = dub.multiply(BigDecimal.TEN)
+        val realDub = dub3.doubleValue(true)
+        assertEquals(Double.MIN_VALUE, realDub)
+    }
 
     @Test
     fun doubleValueTest() {
@@ -31,9 +42,5 @@ class JvmBigDecimalNarrowingTest {
         assertFailsWith<ArithmeticException> {
             f.divide(BigDecimal.TEN).floatValue(true)
         }
-    }
-
-    companion object {
-        val decimalMode = DecimalMode()
     }
 }

--- a/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalNarrowingTest.kt
+++ b/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalNarrowingTest.kt
@@ -5,6 +5,9 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
+/**
+ * nit tests
+ */
 class JvmBigDecimalNarrowingTest {
 
     @Test
@@ -15,6 +18,44 @@ class JvmBigDecimalNarrowingTest {
         val dub3 = dub.multiply(BigDecimal.TEN)
         val realDub = dub3.doubleValue(true)
         assertEquals(Double.MIN_VALUE, realDub)
+
+        val bigNumber = "12345678901234567890.123456789"
+        val divisior = "87654.7654"
+        val maxPrecision = bigNumber.length
+
+        val javaDub = java.math.BigDecimal(bigNumber)
+        val javaResult = javaDub.divide(java.math.BigDecimal(divisior), java.math.MathContext(maxPrecision, java.math.RoundingMode.HALF_UP))
+        val result = BigDecimal.parseStringWithMode(bigNumber)
+        assertFailsWith<ArithmeticException> {
+            result.divide(BigDecimal.parseStringWithMode(divisior))
+        }
+        val result2 = result.divide(BigDecimal.parseStringWithMode(divisior), DecimalMode(maxPrecision.toLong(), RoundingMode.ROUND_HALF_AWAY_FROM_ZERO))
+        val javaStr = javaResult.toEngineeringString().trimEnd('0')
+        val str = result2.toStringExpanded()
+        assertEquals(javaStr, str)
+        assertFailsWith<ArithmeticException> {
+            result2.doubleValue(true)
+        }
+        assertFailsWith<ArithmeticException> {
+            result2.floatValue(true)
+        }
+
+        val javaDubN = java.math.BigDecimal(bigNumber).negate()
+        val javaResultN = javaDubN.divide(java.math.BigDecimal(divisior).negate(), java.math.MathContext(maxPrecision, java.math.RoundingMode.HALF_UP))
+        val resultN = BigDecimal.parseStringWithMode(bigNumber).negate()
+        assertFailsWith<ArithmeticException> {
+            resultN.divide(BigDecimal.parseStringWithMode(divisior).negate())
+        }
+        val result2N = resultN.divide(BigDecimal.parseStringWithMode(divisior).negate(), DecimalMode(maxPrecision.toLong(), RoundingMode.ROUND_HALF_AWAY_FROM_ZERO))
+        val javaStrN = javaResultN.toEngineeringString().trimEnd('0')
+        val strN = result2N.toStringExpanded()
+        assertEquals(javaStrN, strN)
+        assertFailsWith<ArithmeticException> {
+            result2N.doubleValue(true)
+        }
+        assertFailsWith<ArithmeticException> {
+            result2N.floatValue(true)
+        }
     }
 
     @Test
@@ -41,6 +82,52 @@ class JvmBigDecimalNarrowingTest {
         assertEquals(Float.MIN_VALUE, f.floatValue(true))
         assertFailsWith<ArithmeticException> {
             f.divide(BigDecimal.TEN).floatValue(true)
+        }
+    }
+
+    @Test
+    fun shortValueTest() {
+        val i = BigDecimal.fromShort(Short.MAX_VALUE)
+        assertEquals(Short.MAX_VALUE, i.shortValue())
+        assertFailsWith<ArithmeticException> {
+            i.plus(BigDecimal.ONE).shortValue(true)
+        }
+
+        val iN = BigDecimal.fromShort(Short.MIN_VALUE)
+        assertEquals(Short.MIN_VALUE, iN.shortValue())
+        assertFailsWith<ArithmeticException> {
+            iN.minus(BigDecimal.ONE).shortValue(true)
+        }
+    }
+
+    @Test
+    fun intValueTest() {
+        val i = BigDecimal.fromInt(Int.MAX_VALUE)
+        assertEquals(Int.MAX_VALUE, i.intValue())
+        assertFailsWith<ArithmeticException> {
+            i.plus(BigDecimal.ONE).intValue(true)
+        }
+
+        val iN = BigDecimal.fromInt(Int.MIN_VALUE)
+        assertEquals(Int.MIN_VALUE, iN.intValue())
+        assertFailsWith<ArithmeticException> {
+            iN.minus(BigDecimal.ONE).intValue(true)
+        }
+    }
+
+    @Test
+    fun longValueTest() {
+        val i = BigDecimal.fromLong(Long.MAX_VALUE)
+        assertEquals(Long.MAX_VALUE, i.longValue())
+        assertFailsWith<ArithmeticException> {
+            i.plus(BigDecimal.ONE).longValue(true)
+        }
+
+        // kludge this for now because BigInteger longValue has error when MIN_VALUE is set
+        val iN = BigDecimal.fromLong(Long.MIN_VALUE + 1)
+        assertEquals(Long.MIN_VALUE+1, iN.longValue())
+        assertFailsWith<ArithmeticException> {
+            iN.minus(BigDecimal.ONE).minus(BigDecimal.ONE).longValue(true)
         }
     }
 }

--- a/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalNarrowingTest.kt
+++ b/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalNarrowingTest.kt
@@ -1,0 +1,39 @@
+package com.ionspin.kotlin.bignum.decimal
+
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+class JvmBigDecimalNarrowingTest {
+
+    @Test
+    fun doubleValueTest() {
+        var dub = BigDecimal.fromDouble(Double.MAX_VALUE)
+        assertEquals(Double.MAX_VALUE, dub.doubleValue(true))
+        dub = BigDecimal.fromDouble(-Double.MAX_VALUE)
+        assertEquals(-Double.MAX_VALUE, dub.doubleValue(true))
+        dub = BigDecimal.fromDouble(Double.MIN_VALUE)
+        assertEquals(Double.MIN_VALUE, dub.doubleValue(true))
+        val dub2 = dub.divide(BigDecimal.TEN)
+        assertFailsWith<ArithmeticException> {
+            dub2.doubleValue(true)
+        }
+    }
+
+    @Test
+    fun floatValueTest() {
+        var f = BigDecimal.fromFloat(Float.MAX_VALUE)
+        assertEquals(Float.MAX_VALUE, f.floatValue(true))
+        f = BigDecimal.fromFloat(-Float.MAX_VALUE)
+        assertEquals(-Float.MAX_VALUE, f.floatValue(true))
+        f = BigDecimal.fromFloat(Float.MIN_VALUE)
+        assertEquals(Float.MIN_VALUE, f.floatValue(true))
+        assertFailsWith<ArithmeticException> {
+            f.divide(BigDecimal.TEN).floatValue(true)
+        }
+    }
+
+    companion object {
+        val decimalMode = DecimalMode()
+    }
+}

--- a/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalNarrowingTest.kt
+++ b/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalNarrowingTest.kt
@@ -6,7 +6,9 @@ import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 /**
- * nit tests
+ * Unit tests (JVM for easy debugging) on Narrowing functionality for BigDecimal.  Short, Int,
+ * Long are all tested around the edges using the respective MIN_VALUE and MAX_VALUE.  Float
+ * and Double are a little different, but test similar edges.
  */
 class JvmBigDecimalNarrowingTest {
 

--- a/buildSrc/src/main/kotlin/Deps.kt
+++ b/buildSrc/src/main/kotlin/Deps.kt
@@ -20,7 +20,7 @@ object Versions {
     val kotlin = "1.4.0-rc"
     val kotlinSerialization = "1.0-M1-1.4.0-rc"
     val nodePlugin = "1.3.0"
-    val dokkaPlugin = "0.11.0-dev-45"
+    val dokkaPlugin = "1.4.0-rc"
 }
 
 object Deps {

--- a/buildSrc/src/main/kotlin/Deps.kt
+++ b/buildSrc/src/main/kotlin/Deps.kt
@@ -20,7 +20,7 @@ object Versions {
     val kotlin = "1.4.0-rc"
     val kotlinSerialization = "1.0-M1-1.4.0-rc"
     val nodePlugin = "1.3.0"
-    val dokkaPlugin = "1.4.0-M3-dev-92"
+    val dokkaPlugin = "1.4.0-rc"
 }
 
 object Deps {


### PR DESCRIPTION
Narrowing functions that resolves #111 are mostly working. Fix #118 involved not using a roundDiscarded function when using unlimited precision. Also did some minor cleanup of Lint warnings in BigDecimal. Still needs comments, and some changes to BigInteger to allow unit tests to work in certain cases, and probably other stuff.