### PR TITLE
Fix scientific notation parsing

### DIFF
--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
@@ -629,7 +629,13 @@ class BigDecimal private constructor(
             }
             if (floatingPointString.contains('E') || floatingPointString.contains('e')) {
                 // Sci notation
-                val split = floatingPointString.split('.')
+                val split = if (floatingPointString.contains('.').not()) {
+                    // As is case with JS Double.MIN_VALUE
+                    val splitAroundE = floatingPointString.split('E', 'e')
+                    listOf(splitAroundE[0], "0E" + splitAroundE[1])
+                } else {
+                    floatingPointString.split('.')
+                }
                 when (split.size) {
                     2 -> {
                         val signPresent = (floatingPointString[0] == '-' || floatingPointString[0] == '+')

--- a/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalCreationTest.kt
+++ b/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalCreationTest.kt
@@ -104,6 +104,12 @@ class BigDecimalCreationTest {
             val b = BigDecimal.fromIntWithExponent(-123123, 2)
             a == b
         }
+
+        assertTrue {
+            val a = BigDecimal.parseStringWithMode("5E-324")
+            val b = BigDecimal.fromIntWithExponent(5, -324)
+            a == b
+        }
     }
 
     @Test


### PR DESCRIPTION
when string doesn't have a decimal point, like JS Double.MIN_VALUE