### PR TITLE
Add unit test for new scale functionality

### DIFF
--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
@@ -1575,22 +1575,9 @@ class BigDecimal private constructor(
      * 0.0012345678 digitPosition 5, rounding mode HALF_TOWARDS_ZERO will produce 0.00123
      */
     fun roundToDigitPositionAfterDecimalPoint(digitPosition: Long, roundingMode: RoundingMode): BigDecimal {
-        /*
-        return applyScale(significand, exponent,
-            DecimalMode(decimalMode?.decimalPrecision ?: 0, roundingMode, digitPosition))
-
-         */
         if (digitPosition < 0) {
             throw ArithmeticException("This method doesn't support negative digit position")
         }
-        // if (exponent > 0) {
-        //     when {
-        //         precision <= exponent -> return this
-        //         precision > exponent ->
-        //             return this.roundSignificand(DecimalMode(exponent + digitPosition, roundingMode))
-        //         else -> return this
-        //     }
-        // }
         return when {
             exponent >= 0 -> roundToDigitPosition(exponent + digitPosition + 1, roundingMode)
             exponent < 0 -> roundToDigitPosition(digitPosition + 1, roundingMode)

--- a/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalScaleTest.kt
+++ b/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalScaleTest.kt
@@ -1,10 +1,10 @@
 package com.ionspin.kotlin.bignum.decimal
 
+import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import org.junit.Test
 
 /**
  * Unit tests (JVM for easy debugging) on arithmetic operations using the "scale" functionality
@@ -107,5 +107,33 @@ class JvmBigDecimalScaleTest {
         wrk = wrk.scale(2)
         javaWrk = javaWrk.setScale(2)
         assertTrue(wrk.toPlainString().equals(javaWrk.toPlainString()))
+    }
+
+    @Test
+    fun scaleAndNegativeExponentTest() {
+        val r1 = BigDecimal.parseStringWithMode(".0125", DecimalMode(10, RoundingMode.ROUND_HALF_AWAY_FROM_ZERO, 3))
+        val r2 = BigDecimal.parseString(".012")
+        val r3 = BigDecimal.parseString(".013")
+        assertEquals(3, r1.scale)
+        assertEquals(0,r1.compare(r3))
+        assertEquals(1,r1.compare(r2))
+        val r4 = BigDecimal.parseStringWithMode(".0124", DecimalMode(10, RoundingMode.ROUND_HALF_AWAY_FROM_ZERO, 3))
+        assertEquals(-1, r4.compare(r3))
+        assertEquals(0, r4.compare(r2))
+
+        val r5 = BigDecimal.parseStringWithMode(".01234567890123245", DecimalMode(20, RoundingMode.ROUND_HALF_AWAY_FROM_ZERO, 16))
+        val r6 = BigDecimal.parseString(".0123456789012324")
+        val r7 = BigDecimal.parseString(".0123456789012325")
+        assertEquals(16, r5.scale)
+        assertEquals(1,r5.compare(r6))
+        assertEquals(0,r5.compare(r7))
+
+        val rNearZero = BigDecimal.parseStringWithMode(".00005", DecimalMode(20, RoundingMode.ROUND_HALF_AWAY_FROM_ZERO, 4))
+        val r8 = BigDecimal.parseString(".0001")
+        assertEquals(0,rNearZero.compare(r8))
+        var rZero = BigDecimal.parseStringWithMode(".00004", DecimalMode(20, RoundingMode.ROUND_HALF_AWAY_FROM_ZERO, 4))
+        assertEquals(0,rZero.compare(BigDecimal.ZERO))
+        rZero = BigDecimal.parseStringWithMode(".00000004", DecimalMode(20, RoundingMode.ROUND_HALF_AWAY_FROM_ZERO, 4))
+        assertEquals(0,rZero.compare(BigDecimal.ZERO))
     }
 }

--- a/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalScaleTest.kt
+++ b/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalScaleTest.kt
@@ -1,10 +1,10 @@
 package com.ionspin.kotlin.bignum.decimal
 
-import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import org.junit.Test
 
 /**
  * Unit tests (JVM for easy debugging) on arithmetic operations using the "scale" functionality
@@ -115,8 +115,8 @@ class JvmBigDecimalScaleTest {
         val r2 = BigDecimal.parseString(".012")
         val r3 = BigDecimal.parseString(".013")
         assertEquals(3, r1.scale)
-        assertEquals(0,r1.compare(r3))
-        assertEquals(1,r1.compare(r2))
+        assertEquals(0, r1.compare(r3))
+        assertEquals(1, r1.compare(r2))
         val r4 = BigDecimal.parseStringWithMode(".0124", DecimalMode(10, RoundingMode.ROUND_HALF_AWAY_FROM_ZERO, 3))
         assertEquals(-1, r4.compare(r3))
         assertEquals(0, r4.compare(r2))
@@ -125,15 +125,15 @@ class JvmBigDecimalScaleTest {
         val r6 = BigDecimal.parseString(".0123456789012324")
         val r7 = BigDecimal.parseString(".0123456789012325")
         assertEquals(16, r5.scale)
-        assertEquals(1,r5.compare(r6))
-        assertEquals(0,r5.compare(r7))
+        assertEquals(1, r5.compare(r6))
+        assertEquals(0, r5.compare(r7))
 
         val rNearZero = BigDecimal.parseStringWithMode(".00005", DecimalMode(20, RoundingMode.ROUND_HALF_AWAY_FROM_ZERO, 4))
         val r8 = BigDecimal.parseString(".0001")
-        assertEquals(0,rNearZero.compare(r8))
+        assertEquals(0, rNearZero.compare(r8))
         var rZero = BigDecimal.parseStringWithMode(".00004", DecimalMode(20, RoundingMode.ROUND_HALF_AWAY_FROM_ZERO, 4))
-        assertEquals(0,rZero.compare(BigDecimal.ZERO))
+        assertEquals(0, rZero.compare(BigDecimal.ZERO))
         rZero = BigDecimal.parseStringWithMode(".00000004", DecimalMode(20, RoundingMode.ROUND_HALF_AWAY_FROM_ZERO, 4))
-        assertEquals(0,rZero.compare(BigDecimal.ZERO))
+        assertEquals(0, rZero.compare(BigDecimal.ZERO))
     }
 }


### PR DESCRIPTION
Resolves #124 by adding a unit test to test scaling, including scenarios where exponent is negative and scale is > exponent.abs(). (Very small numbers with larger scales).