### PR TITLE
Fix for #127

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Descriptive changelog
 (All dates are DD.MM.YYYY)
+##### 0.2.1 - 8.10.2020 - Fix infinite precision division, kotlin version bump
+- Fixed #127 BigDecimal divide not working properly
+- Added tests to cover case from #127
+- Bumped kotlin to 1.4.10
+- Bumped Dokka to 1.4.10, serialization to 1.0.0 
+
 ##### 0.2.0 - 18.8.2020 - Improvements, optimizations, bugfixes and Kotlin 1.4.0
 - Improvement #122 Add "scale" support to BigDecimal
 - Fixed #118 Rounding issue on division

--- a/bignum/build.gradle.kts
+++ b/bignum/build.gradle.kts
@@ -352,12 +352,6 @@ tasks {
 
     dokkaJavadoc {
         println("Dokka !")
-        dokkaSourceSets {
-            create("commonMain") {
-                displayName = "common"
-                platform = "common"
-            }
-        }
     }
     if (hostOsName == primaryDevelopmentOs) {
         val jvmTest by getting(Test::class) {

--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
@@ -89,7 +89,7 @@ class BigDecimal private constructor(
         override val ZERO = BigDecimal(BigInteger.ZERO)
         override val ONE = BigDecimal(BigInteger.ONE)
         override val TWO = BigDecimal(BigInteger.TWO)
-        override val TEN = BigDecimal(BigInteger.TEN)
+        override val TEN = BigDecimal(BigInteger.TEN, _exponent = 1)
 
         var useToStringExpanded: Boolean = false
 
@@ -1062,7 +1062,11 @@ class BigDecimal private constructor(
      */
     fun divide(other: BigDecimal, decimalMode: DecimalMode? = null): BigDecimal {
         val resolvedDecimalMode = resolveDecimalMode(this.decimalMode, other.decimalMode, decimalMode)
-        var newExponent = this.exponent - other.exponent - 1
+        var newExponent = if (resolvedDecimalMode.isPrecisionUnlimited) {
+            this.exponent - other.exponent
+        } else {
+            this.exponent - other.exponent - 1
+        }
 
         val desiredPrecision = if (resolvedDecimalMode.isPrecisionUnlimited) {
             val precisionSum = max(6, this.precision + other.precision)

--- a/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalDivisionTest.kt
+++ b/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalDivisionTest.kt
@@ -1,0 +1,44 @@
+package com.ionspin.kotlin.bignum.decimal
+
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+/**
+ * Created by Ugljesa Jovanovic
+ * ugljesa.jovanovic@ionspin.com
+ * on 08-Oct-2020
+ */
+class BigDecimalDivisionTest {
+    @Test
+    fun testInfinitePrecisionDivision() {
+        assertTrue {
+            val a = 2.2.toBigDecimal()
+            val b = 2.toBigDecimal()
+            val result = a / b
+            result == 1.1.toBigDecimal()
+        }
+        assertTrue {
+            val a = 2000.212.toBigDecimal()
+            val b = 2.toBigDecimal()
+            val result = a / b
+            result == 1000.106.toBigDecimal()
+        }
+
+        assertTrue {
+            val a = 202020.toBigDecimal()
+            val b = 20.toBigDecimal()
+            val result = a / b
+            result == 10101.toBigDecimal()
+        }
+    }
+
+    @Test
+    fun testInfinitePrecisionNonTerminating() {
+        val a = 1.toBigDecimal()
+        val b = 3.toBigDecimal()
+        assertFailsWith<ArithmeticException> {
+            val result = a / b
+        }
+    }
+}

--- a/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalNarrowingTest.kt
+++ b/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalNarrowingTest.kt
@@ -18,7 +18,7 @@ class JvmBigDecimalNarrowingTest {
         val dub = BigDecimal.fromDouble(Double.MIN_VALUE)
         val dub2 = dub.divide(BigDecimal.TEN)
         assertTrue(dub2 < dub)
-        val dub3 = dub.multiply(BigDecimal.TEN)
+        val dub3 = dub2.multiply(BigDecimal.TEN)
         val realDub = dub3.doubleValue(true)
         assertEquals(Double.MIN_VALUE, realDub)
 

--- a/buildSrc/src/main/kotlin/Deps.kt
+++ b/buildSrc/src/main/kotlin/Deps.kt
@@ -17,10 +17,10 @@
 
 object Versions {
     val kotlinCoroutines = "1.3.9"
-    val kotlin = "1.4.0"
-    val kotlinSerialization = "1.0.0-RC"
+    val kotlin = "1.4.10"
+    val kotlinSerialization = "1.0.0"
     val nodePlugin = "1.3.0"
-    val dokkaPlugin = "1.4.0-rc"
+    val dokkaPlugin = "1.4.10"
 }
 
 object Deps {


### PR DESCRIPTION
Problem was that with introduction of scale, division algorithm has changed, and would return result that had exponent decresead by one from the correct one. Unfortunately this passed through the scale test because `BigInteger.TEN` didn't have correct exponent set and would equal 1 when used. Fixed both issues with this pull request.