### PR TITLE
Resolves #130 Fixes to BigDecimal doubleValue() and fromDouble()

### DIFF
--- a/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalNarrowingTest.kt
+++ b/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalNarrowingTest.kt
@@ -28,6 +28,7 @@ import kotlin.test.assertFailsWith
  */
 
 class BigDecimalNarrowingTest {
+    private val testDouble = 0.000000000000999111999111
 
     @Test
     fun doubleValueTest() {
@@ -39,6 +40,17 @@ class BigDecimalNarrowingTest {
         assertEquals(Double.MIN_VALUE, dub.doubleValue(true))
         assertFailsWith<ArithmeticException> {
             dub.divide(BigDecimal.TEN).doubleValue(true)
+        }
+
+        /*
+         * Test a range of exponents on the testDouble value.  
+         */
+        var dubIn = testDouble
+        for (factor in 0..22) {
+            dubIn *= 10.0
+            val bd = BigDecimal.fromDouble(dubIn)
+            val dubOut = bd.doubleValue(true)
+            assertEquals(dubIn, dubOut)
         }
     }
 


### PR DESCRIPTION
Resolves #130 - Fix to fromDouble companion function, which had a line attempting to remove extraneous trailing zeroes, which was not previously checking foe the presence of an exponent in the double string.  This lead to wrong results when the exponent is present and ends in one or more zeroes (10, 20, 100, -10, etc...) Also doubleValue() previously could return a double with wrong exponent in some cases.