### PR TITLE
Fix biginteger bitwise operations sign

### DIFF
--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/integer/BigInteger.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/integer/BigInteger.kt
@@ -47,6 +47,12 @@ class BigInteger internal constructor(wordArray: WordArray, val sign: Sign) : Bi
     constructor(short: Short) : this(arithmetic.fromShort(short), determinSignFromNumber(short))
     constructor(byte: Byte) : this(arithmetic.fromByte(byte), determinSignFromNumber(byte))
 
+    init {
+        require((sign == Sign.ZERO) xor isResultZero(wordArray).not()) {
+            "sign should be Sign.ZERO iff magnitude has a value of 0"
+        }
+    }
+
     override fun getCreator(): BigNumber.Creator<BigInteger> {
         return BigInteger
     }

--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/integer/BigInteger.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/integer/BigInteger.kt
@@ -560,7 +560,13 @@ class BigInteger internal constructor(wordArray: WordArray, val sign: Sign) : Bi
     }
 
     override infix fun xor(other: BigInteger): BigInteger {
-        return BigInteger(arithmetic.xor(this.magnitude, other.magnitude), sign)
+        val resultMagnitude = arithmetic.xor(this.magnitude, other.magnitude)
+        val resultSign = when {
+            this.isNegative xor other.isNegative -> Sign.NEGATIVE
+            isResultZero(resultMagnitude) -> Sign.ZERO
+            else -> Sign.POSITIVE
+        }
+        return BigInteger(resultMagnitude, resultSign)
     }
 
     /**

--- a/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/integer/integer/BigIntegerBitwiseOperations.kt
+++ b/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/integer/integer/BigIntegerBitwiseOperations.kt
@@ -17,9 +17,27 @@
 
 package com.ionspin.kotlin.bignum.integer.integer
 
+import com.ionspin.kotlin.bignum.integer.BigInteger
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
 /**
  * Created by Ugljesa Jovanovic
  * ugljesa.jovanovic@ionspin.com
  * on 01-Nov-2019
  */
-class BigIntegerBitwiseOperations
+class BigIntegerBitwiseOperations {
+
+    @Test
+    fun `xor with zero`() {
+        val operand = BigInteger.parseString("11110000", 2)
+        val mask = BigInteger.ZERO
+        val xorResult = operand xor mask
+        println("Xor result: ${xorResult.toString(2)}")
+
+        val expectedResult = operand
+
+        assertTrue { xorResult == expectedResult }
+        assertTrue { mask xor operand == expectedResult }
+    }
+}

--- a/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/integer/integer/BigIntegerBitwiseOperations.kt
+++ b/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/integer/integer/BigIntegerBitwiseOperations.kt
@@ -29,7 +29,7 @@ import kotlin.test.assertTrue
 class BigIntegerBitwiseOperations {
 
     @Test
-    fun `xor with zero`() {
+    fun xorWithZero() {
         val operand = BigInteger.parseString("11110000", 2)
         val mask = BigInteger.ZERO
         val xorResult = operand xor mask


### PR DESCRIPTION
The sign of a bitwise xor operation's result was not calculated correctly. The sign of the result was set the sign of the first operand which resulted in 

BigInteger.ONE xor BigInteger.ZERO == BigInteger.ONE while BigInteger.ZERO xor BigInteger.ONE == BigInteger.ZERO
so xor is not commutative and the sign of the result depends on the order of operands.

I amended the logic of the xor output's sign so that:
1. sign is Sign.NEGATIVE iff exactly one of the operands is negative (same as Java's BigInteger)
2. Sign is Sign.ZERO iff magnitude of the result has value of 0
3. else, sign is Sign.Positive

I also added a  basic test for xor of a non-zero number with zero that makes sure it is commutative.

I added an assertion that guards against initialisation of BigInteger when sign == Sign.ZERO but magnitude does not have a value of zero or when magnitude does have a value of 0 but sign != Sign.ZERO.


NOTE:
There could be more tests (maybe using generated data) to verify bitwise operators 
and sign of outputs of 'or' and 'and' needs to be verified as well.