### PR TITLE
Fix biginteger xor operands magnitude array length mismatch

### DIFF
--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/integer/base63/array/BigInteger63Arithmetic.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/integer/base63/array/BigInteger63Arithmetic.kt
@@ -1973,6 +1973,7 @@ internal object BigInteger63Arithmetic : BigIntegerArithmetic {
     }
 
     override fun xor(operand: ULongArray, mask: ULongArray): ULongArray {
+        if (operand.size < mask.size) return xor(mask, operand)
         return removeLeadingZeros(
             ULongArray(operand.size) {
                 if (it < mask.size) {

--- a/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/integer/integer/BigIntegerBitwiseOperations.kt
+++ b/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/integer/integer/BigIntegerBitwiseOperations.kt
@@ -20,7 +20,6 @@ package com.ionspin.kotlin.bignum.integer.integer
 import com.ionspin.kotlin.bignum.integer.BigInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 /**
  * Created by Ugljesa Jovanovic
@@ -38,8 +37,8 @@ class BigIntegerBitwiseOperations {
 
         val expectedResult = operand
 
-        assertTrue { xorResult == expectedResult }
-        assertTrue { mask xor operand == expectedResult }
+        assertEquals(expectedResult, xorResult)
+        assertEquals(expectedResult, mask xor operand)
     }
 
     @Test

--- a/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/integer/integer/BigIntegerBitwiseOperations.kt
+++ b/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/integer/integer/BigIntegerBitwiseOperations.kt
@@ -19,6 +19,7 @@ package com.ionspin.kotlin.bignum.integer.integer
 
 import com.ionspin.kotlin.bignum.integer.BigInteger
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 /**
@@ -39,5 +40,16 @@ class BigIntegerBitwiseOperations {
 
         assertTrue { xorResult == expectedResult }
         assertTrue { mask xor operand == expectedResult }
+    }
+
+    @Test
+    fun xorBiggerThanLongMaxWithZero() {
+        val operand =  BigInteger.parseString("9223372036854775808", 10)
+        val mask = BigInteger.ZERO
+
+        val expectedResult = operand
+
+        assertEquals(expectedResult, operand xor mask)
+        assertEquals(expectedResult, mask xor operand)
     }
 }


### PR DESCRIPTION
Fixed a bug with 'xor' of 'BigInteger'.
The issue originates from BigInteger63Arithmetic::xor which assumes that if magnitude array length of 'operand'
and 'mask' does not match - than mask's one is shorter. However if operand magnitude array's length is the shorter one
the result magnitude is incorrect.

example (with Long.MAX_VALUE + 1):
val big = BigInteger.parseString("9223372036854775808", 10)
big xor BigInteger.ZERO => big (correct)
 BigInteger.ZERO xor big => ZERO (incorrect and should be same as above)

- I added a unit test to verify the correct behaviour
- BigInteger63Arithmetic::or operation, BigInteger63LinkedListArithmetic::or and BigInteger63LinkedListArithmetic::xor might suffer from the same issue
- `Test random xor` could be useful to test xor with random operands and verify the it is commutative but does not seem to test xor... 