### PR TITLE
Add watchosx86 back because it was removed from watchos() in 1.4.30

### DIFF
--- a/bignum/build.gradle.kts
+++ b/bignum/build.gradle.kts
@@ -182,6 +182,13 @@ kotlin {
         }
     }
 
+    watchosX86() {
+        binaries {
+            framework {
+            }
+        }
+    }
+
     mingwX64() {
         binaries {
             staticLib {


### PR DESCRIPTION
Fixes #150