### PR TITLE
fixed removal of leading zero bytes in BigInteger::toByteArray

### DIFF
--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/integer/base63/array/BigInteger63Arithmetic.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/integer/base63/array/BigInteger63Arithmetic.kt
@@ -2222,8 +2222,7 @@ internal object BigInteger63Arithmetic : BigIntegerArithmetic {
         for (i in 0 until as64Bit.size) {
             as64Bit[i].toBigEndianUByteArray().copyInto(result, i * 8, 0, 8)
         }
-        result.dropWhile { it.toUInt() == 0U }.toUByteArray()
-        return result
+        return result.dropWhile { it.toUInt() == 0U }.toUByteArray()
     }
 
     override fun toByteArray(

--- a/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/base63/ByteArrayConversionTest.kt
+++ b/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/base63/ByteArrayConversionTest.kt
@@ -819,4 +819,11 @@ class ByteArrayConversionTest {
         val bignumBackToByteArray = kotlinBig.toByteArray()
         Assert.assertArrayEquals(javaBackToByteArray, bignumBackToByteArray)
     }
+
+    @Test
+    fun reportedIssueTest2() {
+        val javaBigBytes = BigInteger("21000").toByteArray()
+        val kotlinBigBytes = IonSpinBigInteger.parseString("21000").toByteArray()
+        Assert.assertArrayEquals(javaBigBytes, kotlinBigBytes)
+    }
 }


### PR DESCRIPTION
Fixed the removal of leading zero bytes in BigInteger::toByteArray (the result of removal was ignored).
However, this will result in `BigInteger.ZERO.toByteArray == byteArrayOf()` while java's BigInteger will return `byteArrayOf(0)`.
This still causes some test failures in `com.ionspin.kotlin.bignum.integer.ByteArrayConversionTest` that have to be looked into.