### PR TITLE
Decimal mode was expanding significand and messing up the hash code

### DIFF
--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
@@ -1326,7 +1326,7 @@ class BigDecimal private constructor(
                 significand = divisionResult.quotient
             }
         } while (divisionResult.remainder == BigInteger.ZERO)
-        return BigDecimal(significand, bigDecimal.exponent, bigDecimal.decimalMode)
+        return BigDecimal(significand, bigDecimal.exponent)
     }
 
     override fun toString(base: Int): String {
@@ -1704,9 +1704,9 @@ class BigDecimal private constructor(
         val divExponent = precision - 1 - exponent
         val l = this.significand.longValue(exactRequired)
         return if (l.toDouble().toLong() == l && divExponent >= 0 && divExponent < double10pow.size) {
-            l / double10pow[divExponent.toInt()]
+            (l / double10pow[divExponent.toInt()]) * signum()
         } else {
-            this.toString().toDouble()
+            toString().toDouble()
         }
     }
 

--- a/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/decimal/ReportedIssueReplicationTest.kt
+++ b/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/decimal/ReportedIssueReplicationTest.kt
@@ -18,6 +18,8 @@
 package com.ionspin.kotlin.bignum.decimal
 
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
@@ -110,5 +112,39 @@ class ReportedIssueReplicationTest {
         val expectedResult2 = bigDecimalWithModeAtParseTime.divide(divisorWithMode, DECIMAL_MODE)
         println("Expected result 2 (withMode / withMode) $expectedResult2")
         assertTrue { expectedResult2 == unexpectedResult2 }
+    }
+
+    @Test
+    fun testHashCode() {
+        val DECIMAL_MODE = DecimalMode(20, RoundingMode.ROUND_HALF_AWAY_FROM_ZERO, 6)
+        val matchingScaleLastDigitNonZero = "1.23456701E+2"
+        val matchingScaleLastDigitZero = "1.23456700E+2"
+        val smallerScale = "1.23456E+2"
+        val largerScale = "1.23456701234E+2"
+        val msnz = matchingScaleLastDigitNonZero.toBigDecimal()
+        val msnzdm = matchingScaleLastDigitNonZero.toBigDecimal(decimalMode = DECIMAL_MODE)
+        val ms0 = matchingScaleLastDigitZero.toBigDecimal()
+        val ms0dm = matchingScaleLastDigitZero.toBigDecimal(decimalMode = DECIMAL_MODE)
+        val ss = smallerScale.toBigDecimal()
+        val ssdm = smallerScale.toBigDecimal(decimalMode = DECIMAL_MODE)
+        val lsdm = largerScale.toBigDecimal(decimalMode = DECIMAL_MODE)
+        assertEquals(msnz, msnzdm) // ok
+        assertEquals(msnz.hashCode(), msnzdm.hashCode()) // ok
+        assertEquals(ms0, ms0dm) // ok
+        assertEquals(ms0.hashCode(), ms0dm.hashCode()) // hashcodes differ
+        assertEquals(ss, ssdm) // ok
+        assertEquals(ss.hashCode(), ssdm.hashCode()) // hashcodes differ
+        assertEquals(msnz, lsdm) // ok
+        assertEquals(msnz.hashCode(), lsdm.hashCode()) // ok
+    }
+
+    @Test
+    fun testNegativeDouble() {
+        val bigDecimal = BigDecimal.parseString("-1234.1234")
+        assertTrue(bigDecimal.isNegative) // ok
+        val doubleFromString = bigDecimal.toPlainString().toDouble() // ok
+        val asDoubleValue = bigDecimal.doubleValue() // looses the sign
+        assertTrue(doubleFromString < 0)
+        assertFalse(asDoubleValue > 0) // Double is positive...
     }
 }


### PR DESCRIPTION
So we dont return decimal mode when removeTrailingZeroes is applied. Also added signum() to end of doubleValue() conversion so the sign is correct in all cases