### PR TITLE
Kotlin 1.5.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,6 +11,7 @@ workflow:
 
 variables:
   GIT_SUBMODULE_STRATEGY: recursive
+  CHROME_BIN: "chromium"
 
 simpleCheck:
   stage: prepare

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 (All dates are DD.MM.YYYY)
 ##### 0.3.1-SNAPSHOT
 - Fix for #176, a case of unclear API. Methods `roundToDigitPositionAfterDecimalPoint` and `roundToDigitPosition` would set decimal precision to the number of digits present in the result after the rounding was completed. Now they only set decimal precision if it's explicitly set, otherwise it stays unlimited.
+- Bump to 1.5.0
 
 
 ##### 0.3.0 - 17.4.2021

--- a/bignum/build.gradle.kts
+++ b/bignum/build.gradle.kts
@@ -21,7 +21,6 @@ plugins {
     kotlin(PluginsDeps.multiplatform)
     id(PluginsDeps.mavenPublish)
     id(PluginsDeps.signing)
-    id(PluginsDeps.node) version Versions.nodePlugin
     id(PluginsDeps.dokka)
     id(PluginsDeps.spotless) version PluginsDeps.Versions.spotlessVersion
 }
@@ -108,7 +107,7 @@ kotlin {
                 browser() {
                     testTask {
                         useKarma {
-                            usePhantomJS()
+                            useChromeHeadless()
                         }
                     }
                 }

--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/DecimalMode.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/DecimalMode.kt
@@ -93,7 +93,7 @@ data class DecimalMode(
     val usingScale = scale >= 0
 
     init {
-        if (decimalPrecision == 0L && roundingMode != RoundingMode.NONE) {
+        if (usingScale.not() && decimalPrecision == 0L && roundingMode != RoundingMode.NONE) {
             throw ArithmeticException("Rounding mode with 0 digits precision.")
         }
         if (scale < -1) {

--- a/buildSrc/src/main/kotlin/Deps.kt
+++ b/buildSrc/src/main/kotlin/Deps.kt
@@ -18,7 +18,7 @@
 object Versions {
     val kotlinCoroutines = "1.4.2"
     val kotlinCoroutinesMT = "1.4.3-native-mt"
-    val kotlin = "1.4.32"
+    val kotlin = "1.5.0"
     val kotlinSerialization = "1.0.0"
     val nodePlugin = "1.3.0"
     val dokkaPlugin = "1.4.0-rc"


### PR DESCRIPTION
Check for 0 decimal precision and rounding only when scale is not used, bump to 1.5.0, use chrome headless for testing as PhantomJS refused to compile