### PR TITLE
Preserve decimal mode when using unary minus.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ##### 0.3.2-SNAPSHOT
 - Added kotlinx serialization support library
 - Enabled gradle dependencies verification (bootstrapped)
+- Fix for losing decimal mode when using unary minus (#184)
 
 
 ##### 0.3.1

--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
@@ -1592,7 +1592,7 @@ class BigDecimal private constructor(
      * Returns a new negated instance
      */
     override fun unaryMinus(): BigDecimal {
-        return BigDecimal(significand.negate(), exponent)
+        return BigDecimal(significand.negate(), exponent, decimalMode)
     }
 
     override fun secureOverwrite() {

--- a/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalDecimalModeTests.kt
+++ b/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalDecimalModeTests.kt
@@ -1,0 +1,29 @@
+package com.ionspin.kotlin.bignum.decimal
+
+import com.ionspin.kotlin.bignum.runBlockingTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class BigDecimalDecimalModeTests {
+
+    @Test
+    fun testModePreservation() = runBlockingTest {
+        run {
+            val a = BigDecimal.fromInt(1, DecimalMode(scale = 5, roundingMode = RoundingMode.AWAY_FROM_ZERO))
+            val negated = -a
+            assertEquals(a.decimalMode, negated.decimalMode)
+        }
+
+        run {
+            val a = BigDecimal.fromInt(1, DecimalMode(scale = 5, roundingMode = RoundingMode.AWAY_FROM_ZERO))
+            val absolute = a.abs()
+            assertEquals(a.decimalMode, absolute.decimalMode)
+        }
+
+        run {
+            val a = BigDecimal.fromInt(1, DecimalMode(scale = 5, roundingMode = RoundingMode.AWAY_FROM_ZERO))
+            val negated = a.negate()
+            assertEquals(a.decimalMode, negated.decimalMode)
+        }
+    }
+}

--- a/gradle/verification-metadata.xml
+++ b/gradle/verification-metadata.xml
@@ -3,6 +3,10 @@
    <configuration>
       <verify-metadata>true</verify-metadata>
       <verify-signatures>true</verify-signatures>
+      <trusted-artifacts>
+         <trust file=".*-javadoc[.]jar" regex="true"/>
+         <trust file=".*-sources[.]jar" regex="true"/>
+      </trusted-artifacts>
       <trusted-keys>
          <trusted-key id="015479e1055341431b4545ab72475fd306b9cab7" group="com.googlecode.javaewah" name="JavaEWAH" version="1.1.7"/>
          <trusted-key id="1fa37fbe4453c1073e7ef61d6449005f96bc97a3" group="de.undercouch" name="gradle-download-task" version="4.1.1"/>


### PR DESCRIPTION
 Fixes #184. Also added javadoc and sources as trusted artifacts.