### PR TITLE
Fix long narrowing losing sign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,10 @@
 - Added kotlinx serialization support library
 - Enabled gradle dependencies verification (bootstrapped)
 - Fix for losing decimal mode when using unary minus (#184)
+- Fix for losing sign when narrowing to long from big integer (#186)
 
 
-##### 0.3.1
+##### 0.3.1 - 10.5.2021
 - Fix for #176, a case of unclear API. Methods `roundToDigitPositionAfterDecimalPoint` and `roundToDigitPosition` would set decimal precision to the number of digits present in the result after the rounding was completed. Now they only set decimal precision if it's explicitly set, otherwise it stays unlimited.
 - Bump to 1.5.0
 

--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
@@ -1877,7 +1877,7 @@ class BigDecimal private constructor(
         val divExponent = precision - 1 - exponent
         val l = this.significand.longValue(exactRequired)
         return if (l.toDouble().toLong() == l && divExponent >= 0 && divExponent < double10pow.size) {
-            (l / double10pow[divExponent.toInt()]) * signum()
+            (l / double10pow[divExponent.toInt()])
         } else {
             toString().toDouble()
         }

--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/integer/BigInteger.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/integer/BigInteger.kt
@@ -764,7 +764,7 @@ class BigInteger internal constructor(wordArray: WordArray, requestedSign: Sign)
             val firstBit = magnitude[1] shl 63
             (magnitude[0].toLong() or firstBit.toLong()) * signum()
         } else {
-            return magnitude[0].toLong()
+            return magnitude[0].toLong() * signum()
         }
     }
 

--- a/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/integer/BigIntegerTest.kt
+++ b/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/integer/BigIntegerTest.kt
@@ -253,8 +253,17 @@ BigIntegerTest {
             a.intValue(exactRequired = true) == 2
         }
         assertTrue {
+            val a = (-2).toBigInteger()
+            a.intValue(exactRequired = true) == -2
+        }
+        assertTrue {
             val a = 2.toBigInteger()
             val short: Short = 2
+            a.shortValue(exactRequired = true) == short
+        }
+        assertTrue {
+            val a = (-2).toBigInteger()
+            val short: Short = -2
             a.shortValue(exactRequired = true) == short
         }
         assertTrue {
@@ -263,8 +272,17 @@ BigIntegerTest {
             a.byteValue(exactRequired = true) == byte
         }
         assertTrue {
+            val a = (-2).toBigInteger()
+            val byte: Byte = -2
+            a.byteValue(exactRequired = true) == byte
+        }
+        assertTrue {
             val a = 2.toBigInteger()
             a.longValue(exactRequired = true) == 2L
+        }
+        assertTrue {
+            val a = (-2).toBigInteger()
+            a.longValue(exactRequired = true) == -2L
         }
         assertTrue {
             val a = 2.toBigInteger()


### PR DESCRIPTION
also remove signum from bigdecimal toDouble because it was now being applied twice. Add some tests, update changelog. This fixes #186 