### PR TITLE
support browser-js

### DIFF
--- a/bignum/build.gradle.kts
+++ b/bignum/build.gradle.kts
@@ -90,7 +90,6 @@ kotlin {
             compilations {
                 this.forEach {
                     it.compileKotlinTask.kotlinOptions.sourceMap = true
-                    it.compileKotlinTask.kotlinOptions.moduleKind = "commonjs"
                     it.compileKotlinTask.kotlinOptions.metaInfo = true
 
                     if (it.name == "main") {


### PR DESCRIPTION
I am using BigNum in my database Luposdate3000 (https://github.com/luposdate3000/luposdate3000).
The database is right now targeting JVM and Browser-JS.

To be able to use BigNum (in the browser) I need this one-line patch, because otherwise it won't load.
Right now, my users need to apply this patch on their own.         

To actually use BigNum in an browser, it is currently necessary to add "Int64Array = BigInt64Array" to your javascript BEFORE you attempt to load BigNum.
The BigNum library can than run in any browser which has the Int64Array feature.
The supported Browsers can be seen at https://caniuse.com/?search=Int64Array .
The underlying issue is about how the kotlin compiler is compiling "LongArray" to javascript.
If you remove LongArray from the implementation, than this fix is not necessary.