### PR TITLE
fix Scale error

### DIFF
--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
@@ -2278,7 +2278,7 @@ class BigDecimal private constructor(
     private fun placeADotInStringExpanded(input: String, position: Int): String {
 
         val prefix = input.substring(0 until input.length - position)
-        val suffix = input.substring(input.length - position until input.length).dropLastWhile { it == '0' }
+        val suffix = input.substring(input.length - position until input.length)
 
         return if (suffix.isNotEmpty()) {
             ("$prefix.$suffix")


### PR DESCRIPTION

scale error, for example
var r = 156.10.toBigDecimal().toStringExpanded()
assertEquals("156.10", r)
the result:
expected:<156.1[0]> but was:<156.1[]>
Expected :156.10
Actual :156.1
I expected keep two decimals，but “toStringExpanded “ will remove "0",then result will be error. please help me,thank you

