### PR TITLE
AWAY_FROM_ZERO was skipped when remainder first digit was zero

### DIFF
--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
@@ -89,10 +89,10 @@ class BigDecimal private constructor(
                 decimalMode = _decimalMode.copy(decimalPrecision = precision)
             }
         } else {
-            significand = _significand
-            precision = _significand.numberOfDecimalDigits()
-            exponent = _exponent
-            decimalMode = _decimalMode
+                significand = _significand
+                precision = _significand.numberOfDecimalDigits()
+                exponent = _exponent
+                decimalMode = _decimalMode
         }
     }
 
@@ -189,9 +189,16 @@ class BigDecimal private constructor(
             } else {
                 significand.sign
             }
-
-            if (remainder.isZero()) {
-                return result
+            if (decimalMode.roundingMode != RoundingMode.AWAY_FROM_ZERO &&
+                decimalMode.roundingMode != RoundingMode.TOWARDS_ZERO
+            ) {
+                if (remainder.isZero()) {
+                    return result
+                }
+            } else {
+                if (remainder.isZero() && discarded.isZero()) {
+                    return result
+                }
             }
             val decider = determineDecider(remainder)
             when (decimalMode.roundingMode) {
@@ -389,7 +396,8 @@ class BigDecimal private constructor(
                     when (decimalMode.roundingMode) {
                         RoundingMode.CEILING, RoundingMode.AWAY_FROM_ZERO -> {
                             val increasedSignificand = significand.inc()
-                            val exponentModifier = increasedSignificand.numberOfDecimalDigits() - significand.numberOfDecimalDigits()
+                            val exponentModifier =
+                                increasedSignificand.numberOfDecimalDigits() - significand.numberOfDecimalDigits()
                             BigDecimal(increasedSignificand, exponent + exponentModifier, decimalMode)
                         }
                         else -> BigDecimal(significand, exponent, decimalMode)
@@ -399,7 +407,8 @@ class BigDecimal private constructor(
                     when (decimalMode.roundingMode) {
                         RoundingMode.FLOOR, RoundingMode.AWAY_FROM_ZERO -> {
                             val increasedSignificand = significand.dec()
-                            val exponentModifier = increasedSignificand.numberOfDecimalDigits() - significand.numberOfDecimalDigits()
+                            val exponentModifier =
+                                increasedSignificand.numberOfDecimalDigits() - significand.numberOfDecimalDigits()
                             BigDecimal(increasedSignificand, exponent + exponentModifier, decimalMode)
                         }
                         else -> BigDecimal(significand, exponent, decimalMode)
@@ -409,7 +418,11 @@ class BigDecimal private constructor(
             }
         }
 
-        private fun roundSignificand(significand: BigInteger, exponent: Long, decimalMode: DecimalMode): BigDecimal {
+        private fun roundSignificand(
+            significand: BigInteger,
+            exponent: Long,
+            decimalMode: DecimalMode
+        ): BigDecimal {
             if (significand == BigInteger.ZERO) {
                 return BigDecimal(BigInteger.ZERO, exponent, decimalMode)
             }
@@ -663,7 +676,9 @@ class BigDecimal private constructor(
         fun fromFloat(float: Float, decimalMode: DecimalMode? = null): BigDecimal {
             val floatString = float.toString()
             return if (floatString.contains('.') && !floatString.contains('E', true)) {
-                parseStringWithMode(floatString.dropLastWhile { it == '0' }, decimalMode).roundSignificand(decimalMode)
+                parseStringWithMode(floatString.dropLastWhile { it == '0' }, decimalMode).roundSignificand(
+                    decimalMode
+                )
             } else {
                 parseStringWithMode(floatString, decimalMode).roundSignificand(decimalMode)
             }
@@ -680,9 +695,12 @@ class BigDecimal private constructor(
         fun fromDouble(double: Double, decimalMode: DecimalMode? = null): BigDecimal {
             val doubleString = double.toString()
             return if (doubleString.contains('.') && !doubleString.contains('E', true)) {
-                parseStringWithMode(doubleString.dropLastWhile { it == '0' }, decimalMode).roundSignificand(decimalMode)
+                parseStringWithMode(doubleString.dropLastWhile { it == '0' }, decimalMode).roundSignificand(
+                    decimalMode
+                )
             } else {
-                parseStringWithMode(doubleString, decimalMode).roundSignificand(decimalMode).roundSignificand(decimalMode)
+                parseStringWithMode(doubleString, decimalMode).roundSignificand(decimalMode)
+                    .roundSignificand(decimalMode)
             }
         }
 
@@ -1046,11 +1064,12 @@ class BigDecimal private constructor(
                 if (firstDecimalMode!!.roundingMode != secondDecimalMode!!.roundingMode) {
                     throw ArithmeticException("Different rounding modes! This: ${firstDecimalMode.roundingMode} Other: ${secondDecimalMode.roundingMode}")
                 }
-                val unifiedDecimalMode = if (firstDecimalMode.decimalPrecision >= secondDecimalMode.decimalPrecision) {
-                    firstDecimalMode
-                } else {
-                    secondDecimalMode
-                }
+                val unifiedDecimalMode =
+                    if (firstDecimalMode.decimalPrecision >= secondDecimalMode.decimalPrecision) {
+                        firstDecimalMode
+                    } else {
+                        secondDecimalMode
+                    }
                 unifiedDecimalMode
             }
         }
@@ -1339,7 +1358,8 @@ class BigDecimal private constructor(
         if (other.abs() > this.abs()) {
             return Pair(ZERO, this)
         }
-        val resolvedRoundingMode = this.decimalMode?.copy(decimalPrecision = exponent + 1) ?: DecimalMode(exponent + 1, RoundingMode.FLOOR)
+        val resolvedRoundingMode =
+            this.decimalMode?.copy(decimalPrecision = exponent + 1) ?: DecimalMode(exponent + 1, RoundingMode.FLOOR)
         val quotient = divide(other, resolvedRoundingMode)
         val quotientInfinitePrecision = quotient.copy(decimalMode = DecimalMode.DEFAULT)
         val remainder = this - (quotientInfinitePrecision * other)
@@ -1837,7 +1857,8 @@ class BigDecimal private constructor(
                 val integerPartBitLength = chosenArithmetic.bitLength(integerPart.magnitude)
 
                 val fractionPart = (significand divrem BigInteger.TEN.pow(precision - exponent - 1)).remainder
-                var fractionConvertTemp = BigDecimal(fractionPart, -1) // this will represent the integer xxxx as 0.xxxx
+                var fractionConvertTemp =
+                    BigDecimal(fractionPart, -1) // this will represent the integer xxxx as 0.xxxx
                 val bitList = mutableListOf<Int>()
                 var counter = 0
                 while (fractionConvertTemp != ZERO && counter <= 24) {
@@ -1916,7 +1937,8 @@ class BigDecimal private constructor(
                 val integerPartBitLength = chosenArithmetic.bitLength(integerPart.magnitude)
 
                 val fractionPart = (significand divrem BigInteger.TEN.pow(precision - exponent - 1)).remainder
-                var fractionConvertTemp = BigDecimal(fractionPart, -1) // this will represent the integer xxxx as 0.xxxx
+                var fractionConvertTemp =
+                    BigDecimal(fractionPart, -1) // this will represent the integer xxxx as 0.xxxx
                 val bitList = mutableListOf<Int>()
                 var counter = 0
                 while (fractionConvertTemp != ZERO && counter <= 53) {
@@ -2140,7 +2162,9 @@ class BigDecimal private constructor(
     private fun javascriptNumberComparison(number: Number): Int {
         val double = number.toDouble()
         return when {
-            double > Long.MAX_VALUE -> { compare(parseString(double.toString())) } // This whole block can be removed after 1.6.20 and https://github.com/JetBrains/kotlin/pull/4364
+            double > Long.MAX_VALUE -> {
+                compare(parseString(double.toString()))
+            } // This whole block can be removed after 1.6.20 and https://github.com/JetBrains/kotlin/pull/4364
             double % 1 == 0.0 -> compare(fromLong(number.toLong()))
             else -> compare(number.toDouble().toBigDecimal())
         }
@@ -2278,7 +2302,10 @@ class BigDecimal private constructor(
 
                 if (diffInt > 0) {
                     val expandZeros = exponent.absoluteValue * '0'
-                    placeADotInStringExpanded(expandZeros + significandString, diffInt + significandString.length - 1)
+                    placeADotInStringExpanded(
+                        expandZeros + significandString,
+                        diffInt + significandString.length - 1
+                    )
                 } else {
                     placeADotInStringExpanded(significandString, significandString.length - 1)
                 }

--- a/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/decimal/ReportedIssueReplicationTest.kt
+++ b/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/decimal/ReportedIssueReplicationTest.kt
@@ -322,4 +322,14 @@ class ReportedIssueReplicationTest {
         val ninePlaces = bigDecimal.moveDecimalPoint(9)
         assertEquals(1123456780L, ninePlaces.longValue())
     }
+
+    @Test
+    fun showBigDecimalWithHigherPrecision() {
+        val bigDecimal = "345.67".toBigDecimal(decimalMode = DecimalMode(scale = 5, roundingMode = RoundingMode.CEILING))
+        println("Significand: ${bigDecimal.significand}")
+        println("Exponent: ${bigDecimal.exponent}")
+        println("Precision ${bigDecimal.precision}")
+        println("Is using scale? ${bigDecimal.usingScale} Scale ${bigDecimal.scale}")
+        println("DecimalMode ${bigDecimal.decimalMode}")
+    }
 }

--- a/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/integer/benchmark/DivisionBenchmark.kt
+++ b/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/integer/benchmark/DivisionBenchmark.kt
@@ -26,6 +26,7 @@ import kotlin.random.nextULong
 import kotlin.test.BeforeTest
 import kotlin.test.Ignore
 import kotlin.test.Test
+import kotlin.test.fail
 import kotlin.time.DurationUnit
 import kotlin.time.ExperimentalTime
 import kotlin.time.measureTime
@@ -75,7 +76,12 @@ class DivisionBenchmark {
                 timeSpent += runDivision(a, b)
             }
         }
-        jobList.forEach { it.join() }
+        jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
 
         println("Total ${timeSpent / 1_000_000} ms (${timeSpent / 1_000_000_000} s) over $numberOfSamples")
         println("Average run ${timeSpent / numberOfSamples} NanoSeconds ${timeSpent / numberOfSamples / 1_000_000} MilliSeconds")
@@ -108,7 +114,12 @@ class DivisionBenchmark {
                 timeSpent += runDivision(a, b)
             }
         }
-        jobList.forEach { it.join() }
+        jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
 
         println("Total ${timeSpent / 1_000_000} ms (${timeSpent / 1_000_000_000} s) over $numberOfSamples")
         println("Average run ${timeSpent / numberOfSamples} NanoSeconds ${timeSpent / numberOfSamples / 1_000_000} MilliSeconds")
@@ -142,7 +153,12 @@ class DivisionBenchmark {
                 timeSpent += runDivision(a, b)
             }
         }
-        jobList.forEach { it.join() }
+        jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
 
         println("Total ${timeSpent / 1_000_000} ms (${timeSpent / 1_000_000_000} s) over $numberOfSamples")
         println("Average run ${timeSpent / numberOfSamples} NanoSeconds ${timeSpent / numberOfSamples / 1_000_000_000} MilliSeconds")

--- a/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/integer/benchmark/MultiplicationBenchmark.kt
+++ b/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/integer/benchmark/MultiplicationBenchmark.kt
@@ -26,6 +26,7 @@ import kotlin.random.nextULong
 import kotlin.test.BeforeTest
 import kotlin.test.Ignore
 import kotlin.test.Test
+import kotlin.test.fail
 import kotlin.time.DurationUnit
 import kotlin.time.ExperimentalTime
 import kotlin.time.measureTime
@@ -75,7 +76,12 @@ class MultiplicationBenchmark {
                 timeSpent += runMultiplication(a, b)
             }
         }
-        jobList.forEach { it.join() }
+        jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
 
         println("Total ${timeSpent / 1_000_000} ms (${timeSpent / 1_000_000_000} s) over $numberOfSamples")
         println("Average run ${timeSpent / numberOfSamples} NanoSeconds ${timeSpent / numberOfSamples / 1_000_000} MilliSeconds")
@@ -108,7 +114,12 @@ class MultiplicationBenchmark {
                 timeSpent += runMultiplication(a, b)
             }
         }
-        jobList.forEach { it.join() }
+        jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
 
         println("Total ${timeSpent / 1_000_000} ms (${timeSpent / 1_000_000_000} s) over $numberOfSamples")
         println("Average run ${timeSpent / numberOfSamples} NanoSeconds ${timeSpent / numberOfSamples / 1_000_000} MilliSeconds")
@@ -142,7 +153,12 @@ class MultiplicationBenchmark {
                 timeSpent += runMultiplication(a, b)
             }
         }
-        jobList.forEach { it.join() }
+        jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
 
         println("Total ${timeSpent / 1_000_000} ms (${timeSpent / 1_000_000_000} s) over $numberOfSamples")
         println("Average run ${timeSpent / numberOfSamples} NanoSeconds ${timeSpent / numberOfSamples / 1_000_000_000} MilliSeconds")

--- a/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalJvmTest.kt
+++ b/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalJvmTest.kt
@@ -20,7 +20,11 @@ package com.ionspin.kotlin.bignum.decimal
 import com.ionspin.kotlin.bignum.integer.BigInteger
 import java.math.MathContext
 import kotlin.random.Random
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.test.fail
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -83,6 +87,9 @@ class BigDecimalJvmTest {
 
         runBlocking {
             jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
                 it.join()
             }
         }
@@ -181,6 +188,9 @@ class BigDecimalJvmTest {
 
         runBlocking {
             jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
                 it.join()
             }
         }
@@ -230,6 +240,9 @@ class BigDecimalJvmTest {
 
         runBlocking {
             jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
                 it.join()
             }
         }
@@ -295,6 +308,9 @@ class BigDecimalJvmTest {
 
         runBlocking {
             jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
                 it.join()
             }
         }
@@ -379,18 +395,16 @@ class BigDecimalJvmTest {
 //        val second = BigDecimal.fromBigIntegerWithExponent(BigInteger.parseStringWithMode("7343078399229486119", 10), 16.toBigInteger())
 //        val first = BigDecimal.fromBigIntegerWithExponent(BigInteger.parseString("-7823836971981477152", 10), 167.toBigInteger())
 //        val second = BigDecimal.fromBigIntegerWithExponent(BigInteger.parseString("-1241920988109618346", 10), 118.toBigInteger())
-        val first = 4.123.toBigDecimal()
-        val second = 2.0.toBigDecimal()
+        val first = BigDecimal.fromBigIntegerWithExponent(BigInteger.parseString("735032083139866985", 10), 124)
+        val second = BigDecimal.fromBigIntegerWithExponent(BigInteger.parseString("6617868532972025548", 10), 19)
 
         val javaBigFirst = first.toJavaBigDecimal()
 
         val javaBigSecond = second.toJavaBigDecimal()
 
-        val result = first.divide(second, DecimalMode(1, RoundingMode.FLOOR))
-        val javaBigResult = javaBigFirst.divide(javaBigSecond, MathContext(1, java.math.RoundingMode.FLOOR))
-        assertTrue {
-            result.toJavaBigDecimal().compareTo(javaBigResult) == 0
-        }
+        val result = first.divide(second, DecimalMode(401, RoundingMode.AWAY_FROM_ZERO))
+        val javaBigResult = javaBigFirst.divide(javaBigSecond, MathContext(401, java.math.RoundingMode.UP))
+        assertEquals(result.toJavaBigDecimal(), javaBigResult)
     }
 
     @Test
@@ -405,13 +419,17 @@ class BigDecimalJvmTest {
 
         runBlocking {
             jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
                 it.join()
             }
         }
     }
 
     private fun singleDivisionTest(first: BigDecimal, second: BigDecimal): Job {
-        return GlobalScope.launch {
+        val testScope = CoroutineScope(Dispatchers.Default)
+        return testScope.launch {
             assertTrue(
                 "Failed on \n" +
                     "val first = BigDecimal.fromBigIntegerWithExponent(BigInteger.parseStringWithMode(\"${first.significand}\", 10), ${first.exponent}.toBigInteger())\n " +
@@ -424,7 +442,12 @@ class BigDecimalJvmTest {
                 val result = first.divide(second, DecimalMode(401, RoundingMode.AWAY_FROM_ZERO))
                 val javaBigResult = javaBigFirst.divide(javaBigSecond, MathContext(401, java.math.RoundingMode.UP))
 
-                result.toJavaBigDecimal().compareTo(javaBigResult) == 0
+                val res = result.toJavaBigDecimal().compareTo(javaBigResult) == 0
+                if (res.not()) {
+                    println("our res  ${result.toJavaBigDecimal()} ")
+                    println("java res $javaBigResult")
+                }
+                res
             }
         }
     }

--- a/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalRoundingTest.kt
+++ b/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalRoundingTest.kt
@@ -21,6 +21,7 @@ import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.test.fail
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -722,7 +723,12 @@ class BigDecimalRoundingTest {
             )
         }
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
     }
 

--- a/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/BigIntegerJvmTest.kt
+++ b/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/BigIntegerJvmTest.kt
@@ -24,6 +24,7 @@ import com.ionspin.kotlin.bignum.toProperType
 import kotlin.random.Random
 import kotlin.random.nextULong
 import kotlin.test.assertTrue
+import kotlin.test.fail
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -79,7 +80,12 @@ class BigIntegerJvmTest {
             jobList.add(job)
         }
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
     }
 

--- a/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/ProfilerRunner.kt
+++ b/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/ProfilerRunner.kt
@@ -22,6 +22,7 @@ import java.math.BigInteger
 import kotlin.random.Random
 import kotlin.random.nextULong
 import kotlin.test.assertTrue
+import kotlin.test.fail
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -87,7 +88,12 @@ class ProfilerRunner {
             jobList.add(job)
         }
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
         val generationEndTime = System.currentTimeMillis()
         println("Done generating samples, took ${generationEndTime - generationStartTime} ms. Generated samples ${sampleList.size}")

--- a/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/base32/BigInteger32JavaBitwiseTest.kt
+++ b/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/base32/BigInteger32JavaBitwiseTest.kt
@@ -20,6 +20,7 @@ package com.ionspin.kotlin.bignum.integer.base32
 import kotlin.random.Random
 import kotlin.random.nextUInt
 import kotlin.test.assertTrue
+import kotlin.test.fail
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -50,7 +51,12 @@ class BigInteger32JavaBitwiseTest {
             )
         }
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
     }
 
@@ -79,7 +85,12 @@ class BigInteger32JavaBitwiseTest {
             )
         }
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
     }
 

--- a/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/base32/BigInteger32JavaDivisionTest.kt
+++ b/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/base32/BigInteger32JavaDivisionTest.kt
@@ -26,6 +26,7 @@ import kotlin.random.Random
 import kotlin.random.nextUInt
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
+import kotlin.test.fail
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -93,7 +94,12 @@ class BigInteger32JavaDivisionTest {
         }
 
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
     }
 
@@ -139,7 +145,12 @@ class BigInteger32JavaDivisionTest {
             )
         }
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
     }
 
@@ -158,7 +169,12 @@ class BigInteger32JavaDivisionTest {
             )
         }
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
     }
 
@@ -182,7 +198,12 @@ class BigInteger32JavaDivisionTest {
             )
         }
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
     }
 
@@ -207,7 +228,12 @@ class BigInteger32JavaDivisionTest {
             )
         }
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
     }
 
@@ -269,6 +295,9 @@ class BigInteger32JavaDivisionTest {
         }
         runBlocking {
             jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
                 it.join()
             }
         }
@@ -302,6 +331,9 @@ class BigInteger32JavaDivisionTest {
         }
         runBlocking {
             jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
                 it.join()
             }
         }
@@ -429,7 +461,12 @@ class DivisionBenchmark {
             jobList.add(job)
         }
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
         val generationEndTime = System.currentTimeMillis()
         println("Done generating samples, took ${generationEndTime - generationStartTime} ms. Generated samples ${sampleList.size}")

--- a/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/base32/BigInteger32JavaMultiplyTest.kt
+++ b/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/base32/BigInteger32JavaMultiplyTest.kt
@@ -23,6 +23,7 @@ import java.time.LocalDateTime
 import kotlin.random.Random
 import kotlin.random.nextUInt
 import kotlin.test.assertTrue
+import kotlin.test.fail
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
@@ -95,7 +96,12 @@ class BigInteger32JavaMultiplyTest {
             )
         }
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
     }
 

--- a/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/base32/BigInteger32JavaStringConversionTests.kt
+++ b/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/base32/BigInteger32JavaStringConversionTests.kt
@@ -21,6 +21,7 @@ import java.math.BigInteger
 import kotlin.random.Random
 import kotlin.random.nextUInt
 import kotlin.test.assertTrue
+import kotlin.test.fail
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -62,7 +63,12 @@ class BigInteger32JavaStringConversionTests {
             )
         }
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
     }
 
@@ -82,7 +88,12 @@ class BigInteger32JavaStringConversionTests {
             )
         }
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
     }
 

--- a/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/base32/BigInteger32JavaSubstractTest.kt
+++ b/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/base32/BigInteger32JavaSubstractTest.kt
@@ -23,6 +23,7 @@ import java.time.LocalDateTime
 import kotlin.random.Random
 import kotlin.random.nextUInt
 import kotlin.test.assertTrue
+import kotlin.test.fail
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -70,7 +71,12 @@ class BigInteger32JavaSubtractTest {
             )
         }
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
     }
 

--- a/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/base32/ByteArrayToAndFromTest.kt
+++ b/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/base32/ByteArrayToAndFromTest.kt
@@ -156,7 +156,12 @@
 //             jobList.add(job)
 //         }
 //         runBlocking {
-//             jobList.forEach { it.join() }
+//             jobList.forEach {
+//                if (it.isCancelled) {
+//                    fail("Some of the tests failed")
+//                }
+//                it.join()
+//            }
 //         }
 //     }
 //
@@ -178,7 +183,12 @@
 //             jobList.add(job)
 //         }
 //         runBlocking {
-//             jobList.forEach { it.join() }
+//             jobList.forEach {
+//                if (it.isCancelled) {
+//                    fail("Some of the tests failed")
+//                }
+//                it.join()
+//            }
 //         }
 //     }
 //

--- a/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/base63/BigInteger63GcdTest.kt
+++ b/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/base63/BigInteger63GcdTest.kt
@@ -21,6 +21,7 @@ import com.ionspin.kotlin.bignum.integer.base63.array.BigInteger63Arithmetic
 import kotlin.random.Random
 import kotlin.random.nextULong
 import kotlin.test.assertTrue
+import kotlin.test.fail
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -58,7 +59,12 @@ class BigInteger63GcdTest {
             jobList.add(job)
         }
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
     }
 

--- a/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/base63/BigInteger63JavaBitwiseTest.kt
+++ b/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/base63/BigInteger63JavaBitwiseTest.kt
@@ -21,6 +21,7 @@ import com.ionspin.kotlin.bignum.integer.base63.array.BigInteger63Arithmetic
 import kotlin.random.Random
 import kotlin.random.nextULong
 import kotlin.test.assertTrue
+import kotlin.test.fail
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -52,7 +53,12 @@ class BigInteger63JavaBitwiseTest {
             )
         }
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
     }
 
@@ -97,7 +103,12 @@ class BigInteger63JavaBitwiseTest {
             )
         }
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
     }
 
@@ -154,7 +165,12 @@ class BigInteger63JavaBitwiseTest {
             )
         }
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
     }
 

--- a/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/base63/BigInteger63JavaDivisionTest.kt
+++ b/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/base63/BigInteger63JavaDivisionTest.kt
@@ -23,6 +23,7 @@ import kotlin.random.Random
 import kotlin.random.nextULong
 import kotlin.test.Ignore
 import kotlin.test.assertTrue
+import kotlin.test.fail
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -107,7 +108,12 @@ class BigInteger63JavaDivisionTest {
             )
         }
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
     }
 
@@ -203,7 +209,12 @@ class BigInteger63JavaDivisionTest {
             jobList.add(job)
         }
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
     }
 
@@ -266,7 +277,12 @@ class BigInteger63JavaDivisionTest {
             jobList.add(job)
         }
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
     }
 
@@ -295,7 +311,12 @@ class BigInteger63JavaDivisionTest {
             jobList.add(job)
         }
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
     }
 
@@ -380,7 +401,12 @@ class DivisionBenchmark {
             jobList.add(job)
         }
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
         val generationEndTime = System.currentTimeMillis()
         println("Done generating samples, took ${generationEndTime - generationStartTime} ms. Generated samples ${sampleList.size}")

--- a/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/base63/BigInteger63JavaMultiplyTest.kt
+++ b/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/base63/BigInteger63JavaMultiplyTest.kt
@@ -24,6 +24,7 @@ import java.time.LocalDateTime
 import kotlin.random.Random
 import kotlin.random.nextULong
 import kotlin.test.assertTrue
+import kotlin.test.fail
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -194,7 +195,12 @@ class BigInteger63JavaMultiplyTest {
             )
         }
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
     }
 

--- a/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/base63/BigInteger63JavaStringConversionTests.kt
+++ b/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/base63/BigInteger63JavaStringConversionTests.kt
@@ -22,6 +22,7 @@ import java.math.BigInteger
 import kotlin.random.Random
 import kotlin.random.nextULong
 import kotlin.test.assertTrue
+import kotlin.test.fail
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -67,7 +68,12 @@ class BigInteger63JavaStringConversionTests {
             )
         }
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
     }
 
@@ -88,7 +94,12 @@ class BigInteger63JavaStringConversionTests {
         }
 
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
     }
 

--- a/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/base63List/BigInteger63ListGcdTest.kt
+++ b/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/base63List/BigInteger63ListGcdTest.kt
@@ -21,6 +21,7 @@ import com.ionspin.kotlin.bignum.integer.base63.BigInteger63LinkedListArithmetic
 import kotlin.random.Random
 import kotlin.random.nextULong
 import kotlin.test.assertTrue
+import kotlin.test.fail
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -60,7 +61,12 @@ class BigInteger63ListGcdTest() {
             jobList.add(job)
         }
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
     }
 

--- a/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/base63List/BigInteger63ListJavaBitwiseTest.kt
+++ b/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/base63List/BigInteger63ListJavaBitwiseTest.kt
@@ -21,6 +21,7 @@ import com.ionspin.kotlin.bignum.integer.base63.BigInteger63LinkedListArithmetic
 import kotlin.random.Random
 import kotlin.random.nextULong
 import kotlin.test.assertTrue
+import kotlin.test.fail
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -52,7 +53,12 @@ class BigInteger63ListJavaBitwiseTest() {
             )
         }
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
     }
 
@@ -97,7 +103,12 @@ class BigInteger63ListJavaBitwiseTest() {
             )
         }
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
     }
 
@@ -155,7 +166,12 @@ class BigInteger63ListJavaBitwiseTest() {
             )
         }
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
     }
 

--- a/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/base63List/BigInteger63ListJavaDivisionTest.kt
+++ b/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/base63List/BigInteger63ListJavaDivisionTest.kt
@@ -21,6 +21,7 @@ import com.ionspin.kotlin.bignum.integer.base63.BigInteger63LinkedListArithmetic
 import kotlin.random.Random
 import kotlin.random.nextULong
 import kotlin.test.assertTrue
+import kotlin.test.fail
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -104,7 +105,12 @@ class BigInteger63ListJavaDivisionTest() {
             )
         }
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
     }
 
@@ -201,7 +207,12 @@ class BigInteger63ListJavaDivisionTest() {
 //
 //        }
 //        runBlocking {
-//            jobList.forEach { it.join() }
+//            jobList.forEach {
+//                if (it.isCancelled) {
+//                    fail("Some of the tests failed")
+//                }
+//                it.join()
+//            }
 //        }
 //    }
 
@@ -267,7 +278,12 @@ class BigInteger63ListJavaDivisionTest() {
 //
 //        }
 //        runBlocking {
-//            jobList.forEach { it.join() }
+//            jobList.forEach {
+//                if (it.isCancelled) {
+//                    fail("Some of the tests failed")
+//                }
+//                it.join()
+//            }
 //        }
 //
 //    }
@@ -298,7 +314,12 @@ class BigInteger63ListJavaDivisionTest() {
 //
 //        }
 //        runBlocking {
-//            jobList.forEach { it.join() }
+//            jobList.forEach {
+//                if (it.isCancelled) {
+//                    fail("Some of the tests failed")
+//                }
+//                it.join()
+//            }
 //        }
 //
 //    }
@@ -385,7 +406,12 @@ class BigInteger63ListJavaDivisionTest() {
 //            jobList.add(job)
 //        }
 //        runBlocking {
-//            jobList.forEach { it.join() }
+//            jobList.forEach {
+//                if (it.isCancelled) {
+//                    fail("Some of the tests failed")
+//                }
+//                it.join()
+//            }
 //        }
 //        val generationEndTime = System.currentTimeMillis()
 //        println("Done generating samples, took ${generationEndTime - generationStartTime} ms. Generated samples ${sampleList.size}")

--- a/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/base63List/BigInteger63ListJavaMultiplyTest.kt
+++ b/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/base63List/BigInteger63ListJavaMultiplyTest.kt
@@ -25,6 +25,7 @@ import java.time.LocalDateTime
 import kotlin.random.Random
 import kotlin.random.nextULong
 import kotlin.test.assertTrue
+import kotlin.test.fail
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -195,7 +196,12 @@ class BigInteger63LinkedListJavaMultiplyTest {
             )
         }
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
     }
 

--- a/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/base63List/BigInteger63ListJavaStringConversionTests.kt
+++ b/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/base63List/BigInteger63ListJavaStringConversionTests.kt
@@ -22,6 +22,7 @@ import java.math.BigInteger
 import kotlin.random.Random
 import kotlin.random.nextULong
 import kotlin.test.assertTrue
+import kotlin.test.fail
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -67,7 +68,12 @@ class BigInteger63ListJavaStringConversionTests() {
             )
         }
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
     }
 
@@ -88,7 +94,12 @@ class BigInteger63ListJavaStringConversionTests() {
         }
 
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
     }
 

--- a/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/benchmark/JavaMultiplicationBenchmark.kt
+++ b/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/integer/benchmark/JavaMultiplicationBenchmark.kt
@@ -28,6 +28,7 @@ import kotlin.random.nextULong
 import kotlin.test.BeforeTest
 import kotlin.test.Ignore
 import kotlin.test.Test
+import kotlin.test.fail
 import kotlin.time.DurationUnit
 import kotlin.time.ExperimentalTime
 import kotlin.time.measureTime
@@ -79,7 +80,12 @@ class JavaMultiplicationBenchmark {
                 javaTimeSpent += runJavaMultipltication(a, b)
             }
         }
-        jobList.forEach { it.join() }
+        jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
 
         println("Total ${timeSpent / 1_000_000} ms (${timeSpent / 1_000_000_000} s) over $numberOfSamples")
         println("Average run ${timeSpent / numberOfSamples} NanoSeconds ${timeSpent / numberOfSamples / 1_000_000_000} MilliSeconds")
@@ -117,7 +123,12 @@ class JavaMultiplicationBenchmark {
                 javaTimeSpent += runJavaMultipltication(a, b)
             }
         }
-        jobList.forEach { it.join() }
+        jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
 
         println("Total ${timeSpent / 1_000_000} ms (${timeSpent / 1_000_000_000} s) over $numberOfSamples")
         println("Average run ${timeSpent / numberOfSamples} NanoSeconds ${timeSpent / numberOfSamples / 1_000_000_000} MilliSeconds")
@@ -156,7 +167,12 @@ class JavaMultiplicationBenchmark {
                 javaTimeSpent += runJavaMultipltication(a, b)
             }
         }
-        jobList.forEach { it.join() }
+        jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
 
         println("Total ${timeSpent / 1_000_000} ms (${timeSpent / 1_000_000_000} s) over $numberOfSamples")
         println("Average run ${timeSpent / numberOfSamples} NanoSeconds ${timeSpent / numberOfSamples / 1_000_000_000} MilliSeconds")

--- a/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/modular/JvmModularBigIntegerExponentiationTest.kt
+++ b/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/modular/JvmModularBigIntegerExponentiationTest.kt
@@ -25,6 +25,7 @@ import kotlin.random.Random
 import kotlin.random.nextULong
 import kotlin.test.Test
 import kotlin.test.assertTrue
+import kotlin.test.fail
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -67,7 +68,12 @@ class JvmModularBigIntegerExponentiationTest {
             jobList.add(job)
         }
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
     }
 

--- a/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/modular/ModularBigIntegerDivisionTest.kt
+++ b/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/modular/ModularBigIntegerDivisionTest.kt
@@ -24,6 +24,7 @@ import com.ionspin.kotlin.bignum.toProperType
 import kotlin.random.Random
 import kotlin.random.nextULong
 import kotlin.test.assertTrue
+import kotlin.test.fail
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -70,7 +71,12 @@ class ModularBigIntegerDivisionTest {
             jobList.add(job)
         }
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
     }
 

--- a/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/modular/ModularBigIntegerMultiplication.kt
+++ b/bignum/src/jvmTest/kotlin/com/ionspin/kotlin/bignum/modular/ModularBigIntegerMultiplication.kt
@@ -25,6 +25,7 @@ import kotlin.random.Random
 import kotlin.random.nextULong
 import kotlin.test.Test
 import kotlin.test.assertTrue
+import kotlin.test.fail
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
@@ -68,7 +69,12 @@ class ModularBigIntegerMultiplication {
             jobList.add(job)
         }
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
     }
 
@@ -102,7 +108,12 @@ class ModularBigIntegerMultiplication {
             jobList.add(job)
         }
         runBlocking {
-            jobList.forEach { it.join() }
+            jobList.forEach {
+                if (it.isCancelled) {
+                    fail("Some of the tests failed")
+                }
+                it.join()
+            }
         }
     }
 


### PR DESCRIPTION
, also all tests that use coroutines now fail if any of the jobs fail. Fixes #245