### PR TITLE
Make BigInteger.arithmetic public

### DIFF
--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/integer/BigInteger.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/integer/BigInteger.kt
@@ -72,7 +72,7 @@ class BigInteger internal constructor(wordArray: WordArray, requestedSign: Sign)
     }
 
     companion object : BigNumber.Creator<BigInteger>, BigNumber.Util<BigInteger>, ByteArrayDeserializable<BigInteger> {
-        private val arithmetic: BigIntegerArithmetic = chosenArithmetic
+        val arithmetic: BigIntegerArithmetic = chosenArithmetic
 
         override val ZERO = BigInteger(arithmetic.ZERO, Sign.ZERO)
         override val ONE = BigInteger(arithmetic.ONE, Sign.POSITIVE)


### PR DESCRIPTION
# Motivation: 

I need a method to get the length of a number in bits (BigIntegerArithmetic.bitLength), besides this interface is public, but there are no ways to get an instance except through this constant