### PR TITLE
Kotlin to 1.8.20, bug fixes, API improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build/
 /bignum/node_modules
 /buildSrc/out
 /bignum/node_modules
+zignum/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 (All dates are DD.MM.YYYY)
 
 ##### 0.3.8-SNAPSHOT - current snapshot
+- Bump to Kotlin 1.8.10
+- Fix for #253, empty string is not a valid floating point number any more and parsing it throws ArithmeticException
+- Fix for #245, division test failures run in coroutines were ignored.
+- Expanded BigInteger API to expose bitLength as proposed by #254
 
 ##### 0.3.7 - 6.8.2022
 - Bump to Kotlin 1.7.10

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ and bug-fixing.
 
 #### Gradle
 ```kotlin
-implementation("com.ionspin.kotlin:bignum:0.3.7")
+implementation("com.ionspin.kotlin:bignum:0.3.8")
 ```
 
 #### Snapshot builds
@@ -37,7 +37,7 @@ repositories {
         url = uri("https://oss.sonatype.org/content/repositories/snapshots")
     }
 }
-implementation("com.ionspin.kotlin:bignum:0.3.8-SNAPSHOT")
+implementation("com.ionspin.kotlin:bignum:0.3.9-SNAPSHOT")
 
 ```
 

--- a/bignum-serialization-kotlinx/src/commonMain/kotlin/com/ionspin/kotlin/bignum/serialization/kotlinx/biginteger/BigIntegerArraySerializer.kt
+++ b/bignum-serialization-kotlinx/src/commonMain/kotlin/com/ionspin/kotlin/bignum/serialization/kotlinx/biginteger/BigIntegerArraySerializer.kt
@@ -4,7 +4,6 @@ import com.ionspin.kotlin.bignum.integer.BigInteger
 import com.ionspin.kotlin.bignum.integer.Sign
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.builtins.ArraySerializer
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -24,8 +23,7 @@ import kotlinx.serialization.modules.SerializersModule
  * on 04-Jul-2021
  */
 
-@OptIn(ExperimentalStdlibApi::class, ExperimentalSerializationApi::class, ExperimentalUnsignedTypes::class)
-@Serializer(forClass = BigInteger::class)
+@OptIn(ExperimentalSerializationApi::class, ExperimentalUnsignedTypes::class)
 object BigIntegerArraySerializer : KSerializer<BigInteger> {
 
 

--- a/bignum-serialization-kotlinx/src/commonMain/kotlin/com/ionspin/kotlin/bignum/serialization/kotlinx/biginteger/BigIntegerHumanReadableSerializer.kt
+++ b/bignum-serialization-kotlinx/src/commonMain/kotlin/com/ionspin/kotlin/bignum/serialization/kotlinx/biginteger/BigIntegerHumanReadableSerializer.kt
@@ -2,7 +2,6 @@ package com.ionspin.kotlin.bignum.serialization.kotlinx.biginteger
 
 import com.ionspin.kotlin.bignum.integer.BigInteger
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
 import kotlinx.serialization.descriptors.PrimitiveKind
 import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
 import kotlinx.serialization.descriptors.SerialDescriptor
@@ -17,7 +16,6 @@ import kotlinx.serialization.modules.SerializersModule
  *
  * Serializes big integer into base 10 human readable format.
  */
-@Serializer(forClass = BigInteger::class)
 object BigIntegerHumanReadableSerializer : KSerializer<BigInteger> {
 
     override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("BigInteger", PrimitiveKind.STRING)

--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/BigNumber.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/BigNumber.kt
@@ -255,6 +255,11 @@ interface BitwiseCapable<BigType> {
      * I.e.: If the number was "1100" binary, not returns "0011" => "11" => 4 decimal
      */
     fun not(): BigType
+
+    /**
+     * Returns the number of bits needed to represent this number
+     */
+    fun bitLength(): Int
 }
 
 interface ByteArraySerializable {

--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
@@ -897,7 +897,7 @@ class BigDecimal private constructor(
          */
         fun parseStringWithMode(floatingPointString: String, decimalMode: DecimalMode? = null): BigDecimal {
             if (floatingPointString.isEmpty()) {
-                return ZERO
+                throw ArithmeticException("Empty string is not a valid decimal number")
             }
             if (floatingPointString.contains('E', true)) {
                 // Sci notation

--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/integer/BigInteger.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/integer/BigInteger.kt
@@ -547,12 +547,16 @@ class BigInteger internal constructor(wordArray: WordArray, requestedSign: Sign)
         return BigInteger(arithmetic.setBitAt(magnitude, position, bit), sign)
     }
 
+    override fun bitLength(): Int {
+        return arithmetic.bitLength(magnitude)
+    }
+
     override fun numberOfDecimalDigits(): Long {
         if (isZero()) {
             return 1
         }
-        val bitLenght = arithmetic.bitLength(magnitude)
-        val minDigit = ceil((bitLenght - 1) * LOG_10_OF_2)
+        val bitLength = arithmetic.bitLength(magnitude)
+        val minDigit = ceil((bitLength - 1) * LOG_10_OF_2)
 //        val maxDigit = floor(bitLenght * LOG_10_OF_2) + 1
 //        val correct = this / 10.toBigInteger().pow(maxDigit.toInt())
 //        return when {

--- a/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/integer/BitwiseTest.kt
+++ b/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/integer/BitwiseTest.kt
@@ -20,6 +20,7 @@ package com.ionspin.kotlin.bignum.integer.arithmetic
 import com.ionspin.kotlin.bignum.integer.BigInteger
 import com.ionspin.kotlin.bignum.integer.toBigInteger
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 /**
@@ -104,6 +105,42 @@ class BitwiseTest {
             val bigInt = BigInteger.fromLong(Long.MAX_VALUE) - 2.toBigInteger().pow(32)
             val result = bigInt.setBitAt(32, true)
             result == (Long.MAX_VALUE.toBigInteger())
+        }
+    }
+
+    @Test
+    fun bitLengthTestSimple() {
+        assertTrue {
+            val bigInt = BigInteger.fromInt(0)
+            val result = bigInt.bitLength()
+            result == 0
+        }
+
+        assertTrue {
+            val bigInt = BigInteger.fromInt(1)
+            val result = bigInt.bitLength()
+            result == 1
+        }
+
+        assertTrue {
+            val bigInt = BigInteger.fromInt(2)
+            val result = bigInt.bitLength()
+            result == 2
+        }
+
+        assertTrue {
+            val bigInt = BigInteger.fromInt(4)
+            val result = bigInt.bitLength()
+            result == 3
+        }
+    }
+
+    @Test
+    fun bitLengthTest() {
+        for (i in 0..4096) {
+            val bigInt = BigInteger.ONE.shl(i)
+            val bitLength = bigInt.bitLength()
+            assertEquals(i + 1, bitLength)
         }
     }
 }

--- a/buildSrc/src/main/kotlin/Deps.kt
+++ b/buildSrc/src/main/kotlin/Deps.kt
@@ -16,9 +16,9 @@
  */
 
 object Versions {
-    val kotlinCoroutines = "1.6.3"
+    val kotlinCoroutines = "1.6.4"
     val kotlin = "1.8.10"
-    val kotlinSerialization = "1.3.3"
+    val kotlinSerialization = "1.5.0-RC"
     val dokkaPlugin = "1.7.20"
 }
 

--- a/buildSrc/src/main/kotlin/Deps.kt
+++ b/buildSrc/src/main/kotlin/Deps.kt
@@ -17,12 +17,12 @@
 
 object Versions {
     val kotlinCoroutines = "1.6.3"
-    val kotlin = "1.7.10"
+    val kotlin = "1.8.10"
     val kotlinSerialization = "1.3.3"
-    val dokkaPlugin = "1.7.10"
+    val dokkaPlugin = "1.7.20"
 }
 
-val projectVersion = "0.3.8-SNAPSHOT"
+val projectVersion = "0.3.9-SNAPSHOT"
 
 object Deps {
 

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -234,10 +234,10 @@ acorn-import-assertions@^1.7.6:
   resolved "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz#ba2b5939ce62c238db6d93d81c9b111b29b855e9"
   integrity sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==
 
-acorn@^8.4.1:
-  version "8.6.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.6.0.tgz#e3692ba0eb1a0c83eaa4f37f5fa7368dd7142895"
-  integrity sha512-U1riIR+lBSNi3IbxtaHOIKdH8sLFv3NYfNv8sg7ZsNhcfl4HF2++BfqqrNAxoCLQW1iiylOj76ecnaUxz+z9yw==
+acorn@^8.7.1:
+  version "8.8.2"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.2.tgz#1b2f25db02af965399b9776b0c2c391276d37c4a"
+  integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==
 
 ajv-keywords@^3.5.2:
   version "3.5.2"
@@ -610,10 +610,10 @@ engine.io@~6.2.0:
     engine.io-parser "~5.0.3"
     ws "~8.2.3"
 
-enhanced-resolve@^5.9.3:
-  version "5.10.0"
-  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.10.0.tgz#0dc579c3bb2a1032e357ac45b8f3a6f3ad4fb1e6"
-  integrity sha512-T0yTFjdpldGY8PmuXXR0PyQ1ufZpEGiHVrp7zHKB7jdR4qlmZHhONVM5AQOAWXuF/w3dnHbEQVrNptJgt7F+cQ==
+enhanced-resolve@^5.10.0:
+  version "5.12.0"
+  resolved "https://registry.yarnpkg.com/enhanced-resolve/-/enhanced-resolve-5.12.0.tgz#300e1c90228f5b570c4d35babf263f6da7155634"
+  integrity sha512-QHTXI/sZQmko1cbDoNAa3mJ5qhWUUNAq3vR0/YiD379fWQrcfuoX1+HW2S0MTt7XmoPLapdaDKUtelUSPic7hQ==
   dependencies:
     graceful-fs "^4.2.4"
     tapable "^2.2.0"
@@ -1672,7 +1672,7 @@ void-elements@^2.0.0:
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
   integrity sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=
 
-watchpack@^2.3.1:
+watchpack@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.4.0.tgz#fa33032374962c78113f93c7f2fb4c54c9862a5d"
   integrity sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==
@@ -1718,21 +1718,21 @@ webpack-sources@^3.2.3:
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
   integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
 
-webpack@5.73.0:
-  version "5.73.0"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.73.0.tgz#bbd17738f8a53ee5760ea2f59dce7f3431d35d38"
-  integrity sha512-svjudQRPPa0YiOYa2lM/Gacw0r6PvxptHj4FuEKQ2kX05ZLkjbVc5MnPs6its5j7IZljnIqSVo/OsY2X0IpHGA==
+webpack@5.74.0:
+  version "5.74.0"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-5.74.0.tgz#02a5dac19a17e0bb47093f2be67c695102a55980"
+  integrity sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==
   dependencies:
     "@types/eslint-scope" "^3.7.3"
     "@types/estree" "^0.0.51"
     "@webassemblyjs/ast" "1.11.1"
     "@webassemblyjs/wasm-edit" "1.11.1"
     "@webassemblyjs/wasm-parser" "1.11.1"
-    acorn "^8.4.1"
+    acorn "^8.7.1"
     acorn-import-assertions "^1.7.6"
     browserslist "^4.14.5"
     chrome-trace-event "^1.0.2"
-    enhanced-resolve "^5.9.3"
+    enhanced-resolve "^5.10.0"
     es-module-lexer "^0.9.0"
     eslint-scope "5.1.1"
     events "^3.2.0"
@@ -1745,7 +1745,7 @@ webpack@5.73.0:
     schema-utils "^3.1.0"
     tapable "^2.1.1"
     terser-webpack-plugin "^5.1.3"
-    watchpack "^2.3.1"
+    watchpack "^2.4.0"
     webpack-sources "^3.2.3"
 
 which@^1.2.1:


### PR DESCRIPTION
Bump kotlin to 1.8.20. Empty string is not valid floating point number any more, fixes #253. Added bitLength to BigInteger/BitwiseCapable API, supersedes #254. Removed unneccessary annotations in json support library.

