### PR TITLE
fix ROUND_HALF_TO_EVEN

### DIFF
--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
@@ -293,26 +293,11 @@ class BigDecimal private constructor(
                 RoundingMode.ROUND_HALF_TO_EVEN -> {
                     when {
                         decider == SignificantDecider.FIVE -> {
-                            if (significand % 2 == BigInteger.ONE) {
+                            if ((significand % 2).abs() == BigInteger.ONE) {
                                 // RoundingMode.HALF_CEILING if the digit to the left of the discarded fraction is odd
                                 when (sign) {
                                     Sign.POSITIVE -> {
                                         if (decider != SignificantDecider.LESS_THAN_FIVE) {
-                                            result++
-                                        }
-                                    }
-                                    Sign.NEGATIVE -> {
-                                        if (decider != SignificantDecider.LESS_THAN_FIVE) {
-                                            result--
-                                        }
-                                    }
-                                    Sign.ZERO -> {
-                                    }
-                                }
-                            } else {
-                                when (sign) {
-                                    Sign.POSITIVE -> {
-                                        if (decider == SignificantDecider.MORE_THAN_FIVE) {
                                             result++
                                         }
                                     }

--- a/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalRoundingTests.kt
+++ b/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalRoundingTests.kt
@@ -246,4 +246,54 @@ class BigDecimalRoundingTests {
         val res = a * b
         assertEquals(res, 0.33.toBigDecimal())
     }
+
+    @Test
+    fun `test ROUND_HALF_TO_EVEN`() {
+        val map = mapOf(
+            -1.005 to -1.00,
+            -1.015 to -1.02,
+            1.015 to 1.02,
+            1.005 to 1.00,
+            1.004 to 1.00,
+            1.006 to 1.01,
+            -1.004 to -1.00,
+            -1.006 to -1.01,
+            .0 to .0
+        )
+        map.forEach {
+            assertEquals(
+                (it.value).toBigDecimal(),
+                BigDecimal.fromBigDecimal(
+                    it.key.toBigDecimal(),
+                    DecimalMode(10, roundingMode = RoundingMode.ROUND_HALF_TO_EVEN, scale = 2)
+                ),
+                "the ${it.key} should round to ${it.value}"
+            )
+        }
+    }
+
+    @Test
+    fun `test ROUND_HALF_TO_ODD`() {
+        val map = mapOf(
+            -1.005 to -1.01,
+            -1.025 to -1.03,
+            1.015 to 1.01,
+            1.005 to 1.01,
+            1.004 to 1.00,
+            1.006 to 1.01,
+            -1.004 to -1.00,
+            -1.006 to -1.01,
+            .0 to .0
+        )
+        map.forEach {
+            assertEquals(
+                (it.value).toBigDecimal(),
+                BigDecimal.fromBigDecimal(
+                    it.key.toBigDecimal(),
+                    DecimalMode(10, roundingMode = RoundingMode.ROUND_HALF_TO_ODD, scale = 2)
+                ),
+                "the ${it.key} should round to ${it.value}"
+            )
+        }
+    }
 }


### PR DESCRIPTION
- change to absolute value when evaluating the rest from division, because can be either 1 or -1
- delete the code that checks decider when decider is already known

Honestly i don't know how this works, please double check this.