### PR TITLE
Fix round to even when exponent is less than 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added wasm-js target
 - Fix for #269, thanks to @CodeServant
 - Fix for #276, BigDecimal divrem was not rounding properly
+- Fix for #277, round half to even was wrong when exponent was 0
 
 ##### 0.3.8 - 11.2.2023
 - Bump to Kotlin 1.8.10

--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
@@ -450,8 +450,13 @@ class BigDecimal private constructor(
             return if (exponent >= 0) {
                 roundSignificand(significand, exponent, workMode)
             } else {
-                val temp = BigDecimal(significand, exponent) + significand.signum()
-                roundSignificand(temp.significand, temp.exponent, workMode) - significand.signum()
+                if (decimalMode.roundingMode == RoundingMode.ROUND_HALF_TO_EVEN) {
+                    val temp = BigDecimal(significand, exponent) + (significand.signum() * 2)
+                    roundSignificand(temp.significand, temp.exponent, workMode) - (significand.signum() * 2)
+                } else {
+                    val temp = BigDecimal(significand, exponent) + significand.signum()
+                    roundSignificand(temp.significand, temp.exponent, workMode) - significand.signum()
+                }
             }
         }
 
@@ -1986,7 +1991,11 @@ class BigDecimal private constructor(
         val rounded = if (this.exponent >= 0) {
             roundSignificand(DecimalMode(digitPosition, roundingMode))
         } else {
-            (this + this.signum()).roundSignificand(DecimalMode(digitPosition, roundingMode)) - this.signum()
+            if (roundingMode == RoundingMode.ROUND_HALF_TO_EVEN) {
+                (this + this.signum() * 2).roundSignificand(DecimalMode(digitPosition, roundingMode)) - this.signum() * 2
+            } else {
+                (this + this.signum()).roundSignificand(DecimalMode(digitPosition, roundingMode)) - this.signum()
+            }
         }
 
         return if (decimalMode == null) {

--- a/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/decimal/ReportedIssueReplicationTest.kt
+++ b/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/decimal/ReportedIssueReplicationTest.kt
@@ -342,4 +342,14 @@ class ReportedIssueReplicationTest {
         assertEquals("5", q.toStringExpanded())
         assertEquals("15.5", r.toStringExpanded())
     }
+
+    @Test
+    fun roundingHalfEven() {
+        val bigDecimal = BigDecimal.parseString("0.5")
+        val rounded = bigDecimal.roundToDigitPositionAfterDecimalPoint(0, roundingMode = RoundingMode.ROUND_HALF_TO_EVEN)
+        assertEquals(
+            BigDecimal.ZERO,
+            rounded
+        )
+    }
 }


### PR DESCRIPTION
When using round to even rounding, and exponent is less than 0, invalid result was provided because adding one signum caused rounding to behave as round up. Fixed by adding 2 * signum when round to even is used. Fixes #277.