### PR TITLE
Improve performances of BigDecimal.numberOfDecimalDigits().

### DIFF
--- a/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalRoundingTests.kt
+++ b/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimalRoundingTests.kt
@@ -31,17 +31,18 @@ class BigDecimalRoundingTests {
 
     @Test
     fun testNumberOfDigits() {
-        val a = BigDecimal.fromIntWithExponent(123, 3)
-        val b = BigDecimal.fromIntWithExponent(1, -3)
-        val c = BigDecimal.fromIntWithExponent(12345, 3)
-        val d = BigDecimal.fromIntAsSignificand(10000)
-        assertTrue {
-            a.numberOfDecimalDigits() == 4L &&
-                    b.numberOfDecimalDigits() == 4L &&
-                    c.numberOfDecimalDigits() == 5L &&
-                    d.numberOfDecimalDigits() == 1L
+        assertEquals(4, BigDecimal.parseString("1230").numberOfDecimalDigits())
+        assertEquals(4, BigDecimal.parseString("0.001").numberOfDecimalDigits())
+        assertEquals(5, BigDecimal.parseString("1234.5").numberOfDecimalDigits())
+        assertEquals(1, BigDecimal.parseString("1.0000").numberOfDecimalDigits())
+        assertEquals(5, BigDecimal.parseString("1.0001000").numberOfDecimalDigits())
+        assertEquals(6, BigDecimal.parseString("10.0001000").numberOfDecimalDigits())
+        assertEquals(1, BigDecimal.parseString("0").numberOfDecimalDigits())
+        assertEquals(1, BigDecimal.parseString("0.0").numberOfDecimalDigits())
+        assertEquals(1, BigDecimal.parseString("00.00").numberOfDecimalDigits())
+        assertEquals(1, BigDecimal.parseString("1").numberOfDecimalDigits())
+        assertEquals(2, BigDecimal.parseString("10").numberOfDecimalDigits())
         }
-    }
 
     @Test
     fun testRoundSignificand() {


### PR DESCRIPTION
During a performance study on our app, we notice that numberOfDecimalDigits was taking a lot of time during our calculations.

![image](https://github.com/ionspin/kotlin-multiplatform-bignum/assets/7968075/b88b5103-bd66-431d-8b60-32f91b60b984)

I've made an adjustment and processed to a simple benchmark on a M3 Pro with this test

```kotlin
    @Test
    fun perfTest() {
        val bd = BigDecimal.parseString("1.0")
        val duration = measureTime {
            repeat(1_000_000) { bd.numberOfDecimalDigits() }
        }
        println("Duration: $duration")
    }
```

Initial results before the changes:

| platform     | Run #1    | Run #2  | Run #3     |
|--------------|-----------|---------|------------|
| iosSimulator | 19.12s    | 17.95s  | **17.91s** |
| JVM          | **536ms** | 538.7ms | 559.1ms    |
| macosArm64   | 18.2s     | 18.3s   | **18.1s**  |

After the changes of the first commit, I obtain

| platform     | Run #1 | Run #2     | Run #3 | Comparison best of 3 |
|--------------|--------|------------|--------|----------------------|
| iosSimulator | 2.02s  | **2.01s**  | 2.10s  | reduction of 88%     |
| JVM          | 90.6ms | **75.2ms** | 88.5ms | reduction of 86%     |
| macosArm64   | 2.10s  | **2.06s**  | 2.07s  | reduction of 88%     |

Major changes:
- removeTrailingZeroes is comparing with `== ZERO` which has quite a big impact (I would like to suggest a second commit where I change all of them by `isZero()` which is more powerful and gives the same result if I'm right.
- removeTrailingZeroes needs to maintain reminder/quotient which requires another check, more memory allocation and is eventually 3x more time (JVM) than my proposal.
