### PR TITLE
Improve performances of BigInteger.numberOfDecimalDigits().

### DIFF
--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/integer/BigInteger.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/integer/BigInteger.kt
@@ -25,6 +25,7 @@ import com.ionspin.kotlin.bignum.CommonBigNumberOperations
 import com.ionspin.kotlin.bignum.NarrowingOperations
 import com.ionspin.kotlin.bignum.decimal.BigDecimal
 import com.ionspin.kotlin.bignum.integer.base63.array.BigInteger63Arithmetic
+import com.ionspin.kotlin.bignum.integer.base63.array.BigInteger63Arithmetic.compareTo
 import com.ionspin.kotlin.bignum.modular.ModularBigInteger
 import kotlin.math.ceil
 import kotlin.math.floor
@@ -555,8 +556,14 @@ class BigInteger internal constructor(wordArray: WordArray, requestedSign: Sign)
         if (isZero()) {
             return 1
         }
-        val bitLength = arithmetic.bitLength(magnitude)
-        val minDigit = ceil((bitLength - 1) * LOG_10_OF_2)
+        // Search through firsts powersOf10
+        val powersOf10 = BigInteger63Arithmetic.powersOf10
+        val quickSearch = powersOf10.indexOfFirst { it > magnitude }
+        if (quickSearch != -1) {
+            return quickSearch.toLong()
+        }
+//        val bitLength = arithmetic.bitLength(magnitude)
+//        val minDigit = ceil((bitLength - 1) * LOG_10_OF_2)
 //        val maxDigit = floor(bitLenght * LOG_10_OF_2) + 1
 //        val correct = this / 10.toBigInteger().pow(maxDigit.toInt())
 //        return when {
@@ -565,13 +572,13 @@ class BigInteger internal constructor(wordArray: WordArray, requestedSign: Sign)
 //            else -> -1
 //        }
 
-        var tmp = this / 10.toBigInteger().pow(minDigit.toInt())
+        var tmp = this / TEN.pow(powersOf10.size)
         var counter = 0L
-        while (tmp.compareTo(0) != 0) {
+        while (!tmp.isZero()) {
             tmp /= 10
             counter++
         }
-        return counter + minDigit.toInt()
+        return counter + powersOf10.size
     }
 
     override infix fun shl(places: Int): BigInteger {


### PR DESCRIPTION
Similar PR than previous one but with focus on the BigInteger.

```kotlin
    @Test
    fun perfTest() {
        val bd = BigInteger.parseString("123")
        val duration = measureTime {
            repeat(1_000_000) { bd.numberOfDecimalDigits() }
        }
        println("Duration: $duration")
    }
```

Result (best of 3 runs)

| platform     | Before | After      | Time reduction   |
|--------------|--------|------------|------------------|
| iosSimulator | 4.60s  | **0.62s**  | reduction of 86% |
| JVM          | 219ms  | **75.2ms** | reduction of 66% |
| macosArm64   | 4.91s  | **0.67ms** | reduction of 86% |

---

### All benchmark data
All runs are done on the same MacBook Pro M3 with 36GB RAM.

Before
- ios 4.83, 4.60, 4.67
- jvm 234ms, 219ms, 241ms
- mac 4.92, 4.91, 4.98

After
- ios 622ms, 617ms, 619ms
- jvm 11.6ms, 9.8ms, 11.4ms
- mac 673ms, 666ms, 666ms

---

Just a side note, I took a relatively short value for the benchmark, I guess performances may vary with length (like the previous implementation). I only run one more test on JVM with "123456789012345678901234567890123456", before 232ms, after 54ms, so I guess we're still in a better place.