### PR TITLE
BigDecimal: Replace ==ZERO by isZero, ~40% time reduction on main methods

### DIFF
--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
@@ -1096,10 +1096,10 @@ class BigDecimal private constructor(
      */
     fun add(other: BigDecimal, decimalMode: DecimalMode? = null): BigDecimal {
         val resolvedDecimalMode = resolveDecimalMode(this.decimalMode, other.decimalMode, decimalMode)
-        if (this == ZERO) {
+        if (this.isZero()) {
             return roundOrDont(other.significand, other.exponent, resolvedDecimalMode)
         }
-        if (other == ZERO) {
+        if (other.isZero()) {
             return roundOrDont(this.significand, this.exponent, resolvedDecimalMode)
         }
         val (first, second, _) = bringSignificandToSameExponent(this, other)
@@ -1153,10 +1153,10 @@ class BigDecimal private constructor(
     fun subtract(other: BigDecimal, decimalMode: DecimalMode? = null): BigDecimal {
         val resolvedDecimalMode = resolveDecimalMode(this.decimalMode, other.decimalMode, decimalMode)
 
-        if (this == ZERO) {
+        if (this.isZero()) {
             return roundOrDont(other.significand.negate(), other.exponent, resolvedDecimalMode)
         }
-        if (other == ZERO) {
+        if (other.isZero()) {
             return roundOrDont(this.significand, this.exponent, resolvedDecimalMode)
         }
 
@@ -1514,7 +1514,7 @@ class BigDecimal private constructor(
      * the same number i.e. 1.234
      */
     private fun removeTrailingZeroes(bigDecimal: BigDecimal): BigDecimal {
-        if (bigDecimal == ZERO) return this
+        if (bigDecimal.isZero()) return this
         var significand = bigDecimal.significand
         var divisionResult = BigInteger.QuotientAndRemainder(bigDecimal.significand, BigInteger.ZERO)
         do {
@@ -1657,7 +1657,7 @@ class BigDecimal private constructor(
      * as division.
      */
     override fun pow(exponent: Long): BigDecimal {
-        if (this == ZERO && exponent < 0) {
+        if (this.isZero() && exponent < 0) {
             throw ArithmeticException("Negative exponentiation of zero is not defined.")
         }
         var result = this
@@ -2167,7 +2167,7 @@ class BigDecimal private constructor(
     }
 
     override fun hashCode(): Int {
-        if (this == ZERO) {
+        if (this.isZero()) {
             return 0
         }
         return removeTrailingZeroes(this).significand.hashCode() + exponent.hashCode()
@@ -2253,7 +2253,7 @@ class BigDecimal private constructor(
      * i.e. 123000000 for 1.23E+9 or 0.00000000123 for 1.23E-9
      */
     fun toStringExpanded(): String {
-        if (this == ZERO) {
+        if (this.isZero()) {
             return "0"
         }
         val digits = significand.numberOfDecimalDigits()


### PR DESCRIPTION
Replacing `== ZERO` by `isZero()` on BigDecimal class.

## Motivation

`equals` method calls `BD.compare(BD)` which requires to bring the significant to same exponent before comparing (if either exponent or precision are not equals). This calculation go through getRidOfRadix and numberOfDecimalDigits which is in total quite expansive.

## Metrics

As I've seen in #299 and #300, optimization gains are relatively similar no matter the platform. To save some time I'll only use JVM (the quickest) to benchmark all public methods directly involving the '== ZERO'. (Don't hesitate to ask me for more benchmarks if you think it's risky.)

## Benchmark (JVM)

Best of 3 runs, 1000000 iterations each, M3 Pro with 36GB RAM, duration in ms

| Method           | BEFORE | AFTER | % time reduction | 
|------------------|--------|-------|------------------|
| subtract         | 395    | 219   | 44%              |
| add              | 287    | 164   | 43%              |
| pow              | 269    | 153   | 43%              |
| hashCode         | 202    | 66    | 67%              |
| add(ZERO)        | 79     | 20    | 75%              |
| toStringExpanded | 167    | 110   | 34%              |

### Benchmark code

```kotlin
    @Test
    fun perfAddZero() {
        val bd = BigDecimal.parseString("123")
        val duration = measureTime {
            repeat(1_000_000) { bd + BigDecimal.ZERO }
        }
        println("add(ZERO): $duration")
    }

    @Test
    fun perfAdd() {
        val a = BigDecimal.parseString("123")
        val b = BigDecimal.parseString("34.56")
        val duration = measureTime {
            repeat(1_000_000) { a + b }
        }
        println("add: $duration")
    }

    @Test
    fun perfSubtract() {
        val a = BigDecimal.parseString("123")
        val b = BigDecimal.parseString("34.56")
        val duration = measureTime {
            repeat(1_000_000) { a - b }
        }
        println("subtract: $duration")
    }

    @Test
    fun perfHashCode() {
        val bd = BigDecimal.parseString("123.45")
        val duration = measureTime {
            // hashCode uses removeTrailingZeroes
            repeat(1_000_000) { bd.hashCode() }
        }
        println("hashCode: $duration")
    }

     @Test
    fun perfPow() {
        val bd = BigDecimal.parseString("123.45")
        val duration = measureTime {
            repeat(1_000_000) { bd.pow(3) }
        }
        println("pow: $duration")
    }

     @Test
    fun perfToStringExpanded() {
        val bd = BigDecimal.parseString("123.45")
        val duration = measureTime {
            repeat(1_000_000) { bd.toStringExpanded() }
        }
        println("toStringExpanded: $duration")
    }
```

### Raw data

#### Before
Run 1
subtract: 395.261291ms
add: 288.861958ms
pow: 282.718375ms
hashCode: 212.823917ms
add(ZERO): 93.253209ms
toStringExpanded: 167.068250ms

Run 2
subtract: 397.731ms
add: 312.411208ms
pow: 269.341042ms
hashCode: 206.681333ms
add(ZERO): 78.573125ms
toStringExpanded: 167.801541ms

Run 3
subtract: 394.628875ms
add: 286.920209ms
pow: 279.920042ms
hashCode: 202.090084ms
add(ZERO): 79.048292ms
toStringExpanded: 176.490833ms

#### After

Run 1
subtract: 225.815875ms
add: 163.852750ms
pow: 155.257792ms
hashCode: 67.060416ms
add(ZERO): 20.868541ms
toStringExpanded: 117.800792ms

Run 2
subtract: 229.606292ms
add: 196.132167ms
pow: 153.424542ms
hashCode: 66.612959ms
add(ZERO): 19.638667ms
toStringExpanded: 109.715250ms

Run 3
subtract: 219.301333ms
add: 187.846375ms
pow: 157.756ms
hashCode: 66.152625ms
add(ZERO): 20.008958ms
toStringExpanded: 111.473625ms
