### PR TITLE
BigDecimal: roundSignificand perf improvement (when using scale)

### DIFF
--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
@@ -385,7 +385,7 @@ class BigDecimal private constructor(
             exponent: Long,
             decimalMode: DecimalMode
         ): BigDecimal {
-            if (significand == BigInteger.ZERO) {
+            if (significand.isZero()) {
                 return BigDecimal(BigInteger.ZERO, exponent, decimalMode)
             }
             val significandDigits = significand.numberOfDecimalDigits()
@@ -395,7 +395,7 @@ class BigDecimal private constructor(
                 decimalMode.decimalPrecision
             }
             return when {
-                desiredPrecision > significandDigits -> {
+                desiredPrecision > significandDigits && !decimalMode.usingScale -> {
                     val extendedSignificand = significand * BigInteger.TEN.pow(desiredPrecision - significandDigits)
                     BigDecimal(extendedSignificand, exponent, decimalMode)
                 }


### PR DESCRIPTION
- use isZero instead of comparing with BigInteger.ZERO (I forgot this one on the other PRs...)
- skip the extendedSignificand when using scale. 
- 
> [!Important]
> I understand that when using scale, `BigDecimal(BigInteger(123), exponent, decimalMode) == BigDecimal(BigInteger(12300000), exponent, decimalMode)`, no matter the exponent or decimalMode. If this is true, then we don't need to calculate the 'pow' and this PR is relevant. Please be aware here I'm not very experimented so that's a supposition.

Many methods are impacted by this method, as I don't have much time right now I've only experimented `add` with **BigDecimals using scale** (performance without scale would be roughly similar), but I guess many other methods may have roughly the same improvement.

Benchmark on JVM, best of 3 runs, M3 Pro 36GB, 10 million iterations, with a warmup loop for JVM (starttime and JIT excluded for a more stable duration).

Code to reproduce:

```kotlin
    @Test
    fun perfAdd1() {
        val a = BigDecimal.parseString("1.01").scale(2)
        val b = BigDecimal.parseString("2.22").scale(2)
        repeat(1_000_000) { // JVM Warmup
            a.add(b)
        }
        val duration = measureTime {
            repeat(10_000_000) {
                a.add(b)
            }
        }
        println("Duration: $duration")
    }
```

| Method          | BEFORE | AFTER | % time reduction | 
|-----------------|--------|-------|------------------|
| add        | 12.0   | 11.4  | 5%               |

Important note here, this is computed on main branch as the other PRs are not yet validated. On my fork, I've merged them all on a temporary branch and re-run the same benchmark. Savings are way better and then this optimisation is saving 45% of the time when using the scale. 

| Method          | BEFORE | AFTER | % time reduction | 
|-----------------|--------|-------|------------------|
| add        | 2.17   | 1.19  | 45%               |

Eventually with the 5 PRs we're passing from 12s to 1.19s, so a total **90% time reduction** 🎉 

--- 

Raw benchmark data

 * Before
 * Duration: 12.197146042s
 * Duration: 12.023203292s
 * Duration: 12.470724917s
 *
 * After
 * Duration: 11.589598666s
 * Duration: 11.617750s
 * Duration: 11.409660500s

(from fork branch with all improvements)
 * Before
 * Duration: 2.305555875s
 * Duration: 2.381971125s
 * Duration: 2.165184959s
 *
 * After
 * Duration: 1.188598625s
 * Duration: 1.266141417s
 * Duration: 1.318251250s
