### PR TITLE
Fix invalid rounding

### DIFF
--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/decimal/BigDecimal.kt
@@ -1289,16 +1289,17 @@ class BigDecimal private constructor(
                 newExponent--
             }
             val exponentModifier = result.numberOfDecimalDigits() - resolvedDecimalMode.decimalPrecision
+            val discarded = divRem.remainder * other.significand
 
             return if (usingScale) {
                 BigDecimal(
-                    roundDiscarded(result, divRem.remainder, resolvedDecimalMode),
+                    roundDiscarded(result, discarded, resolvedDecimalMode),
                     newExponent + exponentModifier,
                     resolvedDecimalMode.copy(decimalPrecision = result.numberOfDecimalDigits())
                 )
             } else {
                 BigDecimal(
-                    roundDiscarded(result, divRem.remainder, resolvedDecimalMode),
+                    roundDiscarded(result, discarded, resolvedDecimalMode),
                     newExponent + exponentModifier,
                     resolvedDecimalMode
                 )

--- a/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/decimal/ReportedIssueReplicationTest.kt
+++ b/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/decimal/ReportedIssueReplicationTest.kt
@@ -352,4 +352,12 @@ class ReportedIssueReplicationTest {
             rounded
         )
     }
+
+    @Test
+    fun roundHalfAway() {
+        val result = BigDecimal.fromInt(2)
+            .divide(BigDecimal.fromInt(3), DecimalMode(2, RoundingMode.ROUND_HALF_AWAY_FROM_ZERO))
+            .doubleValue(false)
+        assertEquals(0.67f, result.toFloat())
+    }
 }


### PR DESCRIPTION
Remainder was sent as discarded part, which caused invalid rounding in some situations, now the discarded part is calculated so that decider digit can be correctly extracted. Fixes #313