### PR TITLE
Fix incorrect RoundingMode description

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,8 +470,8 @@ CEILING|Towards positive infinity
 AWAY_FROM_ZERO|Away from zero
 TOWARDS_ZERO| Towards zero
 NONE|Infinite decimalPrecision, and beyond
-ROUND_HALF_AWAY_FROM_ZERO|Round towards nearest integer, using towards zero as tie breaker when significant digit being rounded is 5
-ROUND_HALF_TOWARDS_ZERO|Round towards nearest integer, using away from zero as tie breaker when significant digit being rounded is 5
+ROUND_HALF_AWAY_FROM_ZERO|Round towards nearest integer, using away from zero as tie breaker when significant digit being rounded is 5
+ROUND_HALF_TOWARDS_ZERO|Round towards nearest integer, using towards zero as tie breaker when significant digit being rounded is 5
 ROUND_HALF_CEILING|Round towards nearest integer, using towards infinity as tie breaker when significant digit being rounded is 5
 ROUND_HALF_FLOOR|Round towards nearest integer, using towards negative infinity as tie breaker when significant digit being rounded is 5
 


### PR DESCRIPTION
The descriptions for `ROUND_HALF_AWAY_FROM_ZERO` and `ROUND_HALF_TOWARDS_ZERO` were flipped