### PR TITLE
Fixed toByteArray

### DIFF
--- a/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/integer/base63/array/BigInteger63Arithmetic.kt
+++ b/bignum/src/commonMain/kotlin/com/ionspin/kotlin/bignum/integer/base63/array/BigInteger63Arithmetic.kt
@@ -2229,7 +2229,7 @@ internal object BigInteger63Arithmetic : BigIntegerArithmetic {
     override fun toUByteArray(
         operand: ULongArray
     ): UByteArray {
-        if (operand == ZERO) {
+        if (operand.contentEquals(ZERO)) {
             return UByteArray(1) { 0U }
         }
         val as64Bit = convertTo64BitRepresentation(operand).reversedArray()

--- a/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/decimal/ReportedIssueReplicationTest.kt
+++ b/bignum/src/commonTest/kotlin/com/ionspin/kotlin/bignum/decimal/ReportedIssueReplicationTest.kt
@@ -17,7 +17,9 @@
 
 package com.ionspin.kotlin.bignum.decimal
 
+import com.ionspin.kotlin.bignum.integer.BigInteger
 import kotlin.test.Test
+import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -359,5 +361,17 @@ class ReportedIssueReplicationTest {
             .divide(BigDecimal.fromInt(3), DecimalMode(2, RoundingMode.ROUND_HALF_AWAY_FROM_ZERO))
             .doubleValue(false)
         assertEquals(0.67f, result.toFloat())
+    }
+
+    @Test
+    fun github316toByteArrayTest() {
+        val a = BigInteger.ZERO.toByteArray()
+        val b = BigInteger.fromULong(0uL).toByteArray()
+        val c = BigInteger.fromLong(0L).toByteArray()
+        val d = BigInteger.fromInt(0).toByteArray()
+
+        assertContentEquals(a, b)
+        assertContentEquals(a, c)
+        assertContentEquals(a, d)
     }
 }


### PR DESCRIPTION
Function toByteArray now uses contentEquals instead of == when single element is 0. Fixes #316, #280, #281